### PR TITLE
fix gradle tasks issues

### DIFF
--- a/buildSrc/src/main/groovy/nextflow/gradle/plugins/SourcesMatcher.groovy
+++ b/buildSrc/src/main/groovy/nextflow/gradle/plugins/SourcesMatcher.groovy
@@ -41,7 +41,7 @@ class SourcesMatcher {
         }
         matcher.collect { file ->
             def source = file.toString() - "$root.absolutePath/src/main/"
-            return source.split('\\.').dropRight(1).join().split(File.separator).drop(1).join('.')
+            return source.split('\\.').dropRight(1).join().split(File.separator).join('.')
         }
     }
 

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -32,6 +32,21 @@ subprojects {
         mavenCentral()
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(19)
+        }
+    }
+
+    compileJava {
+        options.release.set(11)
+    }
+
+    tasks.withType(GroovyCompile) {
+        sourceCompatibility = '11'
+        targetCompatibility = '11'
+    }
+
     tasks.withType(Jar) {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }

--- a/plugins/nf-nomad/build.gradle
+++ b/plugins/nf-nomad/build.gradle
@@ -98,3 +98,15 @@ test {
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
 }
 
+jar {
+    manifest {
+        attributes(
+                'Manifest-Version':'1.0',
+                'Plugin-Id': project.name,
+                'Plugin-Version': archiveVersion,
+                'Plugin-Class': "nextflow.nomad.NomadPlugin",
+                'Plugin-Provider': 'nextflow',
+                'Plugin-Requires': '>=23.10.0',
+        )
+    }
+}

--- a/plugins/nf-nomad/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-nomad/src/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Manifest-Version: 1.0
-Plugin-Id: nf-nomad
-Plugin-Version: 0.0.1
-Plugin-Class: nextflow.nomad.NomadPlugin
-Plugin-Provider: nextflow
-Plugin-Requires: >=23.10.0
-

--- a/plugins/nf-nomad/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-nomad/src/resources/META-INF/extensions.idx
@@ -1,2 +1,0 @@
-nextflow.nomad.NomadPlugin
-nextflow.nomad.executor.NomadExecutor


### PR DESCRIPTION
I've detected current implementation is not generating the right extension.idx nor manifest.mf due nextflow plugins are not following standard source folders (we are not using the `src/groovy` folder but `src` directly)