### PR TITLE
Mount volume spec

### DIFF
--- a/buildSrc/src/main/groovy/nextflow/gradle/plugins/SourcesMatcher.groovy
+++ b/buildSrc/src/main/groovy/nextflow/gradle/plugins/SourcesMatcher.groovy
@@ -41,7 +41,7 @@ class SourcesMatcher {
         }
         matcher.collect { file ->
             def source = file.toString() - "$root.absolutePath/src/main/"
-            return source.split('\\.').dropRight(1).join().split(File.separator).drop(1).join('.')
+            return source.split('\\.').dropRight(1).join().split(File.separator).join('.')
         }
     }
 

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -32,6 +32,21 @@ subprojects {
         mavenCentral()
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(19)
+        }
+    }
+
+    compileJava {
+        options.release.set(11)
+    }
+
+    tasks.withType(GroovyCompile) {
+        sourceCompatibility = '11'
+        targetCompatibility = '11'
+    }
+
     tasks.withType(Jar) {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }

--- a/plugins/nf-nomad/build.gradle
+++ b/plugins/nf-nomad/build.gradle
@@ -98,3 +98,15 @@ test {
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
 }
 
+jar {
+    manifest {
+        attributes(
+                'Manifest-Version':'1.0',
+                'Plugin-Id': project.name,
+                'Plugin-Version': archiveVersion,
+                'Plugin-Class': "nextflow.nomad.NomadPlugin",
+                'Plugin-Provider': 'nextflow',
+                'Plugin-Requires': '>=23.10.0',
+        )
+    }
+}

--- a/plugins/nf-nomad/src/main/nextflow/nomad/NomadConfig.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/NomadConfig.groovy
@@ -30,6 +30,14 @@ import groovy.util.logging.Slf4j
 class NomadConfig {
     final static protected API_VERSION = "v1"
 
+    final static public String VOLUME_DOCKER_TYPE = "docker"
+    final static public String VOLUME_CSI_TYPE = "csi"
+    final static public String VOLUME_HOST_TYPE = "host"
+
+    final static protected String[] VOLUME_TYPES = [
+            VOLUME_CSI_TYPE, VOLUME_DOCKER_TYPE, VOLUME_HOST_TYPE
+    ]
+
     final NomadClientOpts clientOpts
     final NomadJobOpts jobOpts
 
@@ -57,6 +65,7 @@ class NomadConfig {
         final String region
         final String namespace
         final String dockerVolume
+        final VolumeSpec volumeSpec
 
         NomadJobOpts(Map nomadJobOpts){
             deleteOnCompletion = nomadJobOpts.containsKey("deleteOnCompletion") ?
@@ -71,6 +80,29 @@ class NomadConfig {
             region = nomadJobOpts.region ?: null
             namespace = nomadJobOpts.namespace ?: null
             dockerVolume = nomadJobOpts.dockerVolume ?: null
+            if( dockerVolume ){
+                log.info "dockerVolume config will be deprecated, use volume type:'docker' name:'name' instead"
+            }
+            if( nomadJobOpts.volume && nomadJobOpts.volume instanceof Map){
+                volumeSpec = new VolumeSpec(nomadJobOpts.volume as Map<String, String>)
+            }else{
+                volumeSpec = null
+            }
+        }
+    }
+
+    class VolumeSpec{
+
+        final String type
+        final String name
+
+        VolumeSpec(Map<String, String> volumeConfig){
+            if( !VOLUME_TYPES.contains(volumeConfig.type) )
+                throw new IllegalArgumentException("Volume type $type is not supported")
+            if( !volumeConfig.name )
+                throw new IllegalArgumentException("Volume name is required")
+            this.type = volumeConfig.type
+            this.name = volumeConfig.name
         }
     }
 }

--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
  * Copyright 2023, Stellenbosch University, South Africa
  * Copyright 2022, Center for Medical Genetics, Ghent
  *
@@ -28,6 +29,8 @@ import io.nomadproject.client.models.JobSummary
 import io.nomadproject.client.models.Task
 import io.nomadproject.client.models.TaskGroup
 import io.nomadproject.client.models.TaskGroupSummary
+import io.nomadproject.client.models.VolumeMount
+import io.nomadproject.client.models.VolumeRequest
 import nextflow.nomad.NomadConfig
 
 /**
@@ -80,6 +83,15 @@ class NomadService implements Closeable{
                 name: "group",
                 tasks: [ task ]
         )
+        if( config.jobOpts.volumeSpec){
+            taskGroup.volumes = [:]
+            taskGroup.volumes[config.jobOpts.volumeSpec.name]= new VolumeRequest(
+                    type: config.jobOpts.volumeSpec.type,
+                    source: config.jobOpts.volumeSpec.name,
+                    attachmentMode: "file-system",
+                    accessMode: "multi-node-multi-writer"
+            )
+        }
         return taskGroup
     }
 
@@ -104,6 +116,13 @@ class NomadService implements Closeable{
                     source : config.jobOpts.dockerVolume,
                     readonly : false
             ]
+        }
+        if( config.jobOpts.volumeSpec){
+            String destinationDir = workingDir.split(File.separator).dropRight(2).join(File.separator)
+            task.volumeMounts = [ new VolumeMount(
+                    destination: destinationDir,
+                    volume: config.jobOpts.volumeSpec.name
+            )]
         }
         task
     }

--- a/plugins/nf-nomad/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-nomad/src/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Manifest-Version: 1.0
-Plugin-Id: nf-nomad
-Plugin-Version: 0.0.1
-Plugin-Class: nextflow.nomad.NomadPlugin
-Plugin-Provider: nextflow
-Plugin-Requires: >=23.10.0
-

--- a/plugins/nf-nomad/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-nomad/src/resources/META-INF/extensions.idx
@@ -1,2 +1,0 @@
-nextflow.nomad.NomadPlugin
-nextflow.nomad.executor.NomadExecutor

--- a/plugins/nf-nomad/src/test/nextflow/nomad/NomadConfigSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/NomadConfigSpec.groovy
@@ -119,4 +119,44 @@ class NomadConfigSpec extends Specification {
         expect:
         config.jobOpts.namespace == "namespace"
     }
+
+    void "should instantiate a volume spec if specified"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [volume:[type:"docker", name:"test"]]
+        ])
+
+        then:
+        config.jobOpts.volumeSpec
+        config.jobOpts.volumeSpec.type == NomadConfig.VOLUME_DOCKER_TYPE
+        config.jobOpts.volumeSpec.name == "test"
+
+        when:
+        def config2 = new NomadConfig([
+                jobs: [volume:[type:"csi", name:"test"]]
+        ])
+
+        then:
+        config2.jobOpts.volumeSpec
+        config2.jobOpts.volumeSpec.type == NomadConfig.VOLUME_CSI_TYPE
+        config2.jobOpts.volumeSpec.name == "test"
+
+        when:
+        def config3 = new NomadConfig([
+                jobs: [volume:[type:"host", name:"test"]]
+        ])
+
+        then:
+        config3.jobOpts.volumeSpec
+        config3.jobOpts.volumeSpec.type == NomadConfig.VOLUME_HOST_TYPE
+        config3.jobOpts.volumeSpec.name == "test"
+
+        when:
+        new NomadConfig([
+                jobs: [volume:[type:"not-supported", name:"test"]]
+        ])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
 }

--- a/plugins/nf-nomad/src/test/nextflow/nomad/NomadConfigSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/NomadConfigSpec.groovy
@@ -123,7 +123,7 @@ class NomadConfigSpec extends Specification {
     void "should instantiate a volume spec if specified"() {
         when:
         def config = new NomadConfig([
-                jobs: [volume:[type:"docker", name:"test"]]
+                jobs: [volume : { type "docker" name "test" }]
         ])
 
         then:
@@ -133,7 +133,7 @@ class NomadConfigSpec extends Specification {
 
         when:
         def config2 = new NomadConfig([
-                jobs: [volume:[type:"csi", name:"test"]]
+                jobs: [volume : { type "csi" name "test" }]
         ])
 
         then:
@@ -143,7 +143,7 @@ class NomadConfigSpec extends Specification {
 
         when:
         def config3 = new NomadConfig([
-                jobs: [volume:[type:"host", name:"test"]]
+                jobs: [volume  : { type "host" name "test" }]
         ])
 
         then:
@@ -153,7 +153,7 @@ class NomadConfigSpec extends Specification {
 
         when:
         new NomadConfig([
-                jobs: [volume:[type:"not-supported", name:"test"]]
+                jobs: [volume : { type "not-supported" name "test" }]
         ])
 
         then:

--- a/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
@@ -195,7 +195,7 @@ class NomadServiceSpec extends Specification{
                         address : "http://${mockWebServer.hostName}:${mockWebServer.port}"
                 ],
                 jobs:[
-                        volume: [ name:'test', type:'csi']
+                        volume: { type "csi" name "test" }
                 ]
         )
         def service = new NomadService(config)


### PR DESCRIPTION
close #13 

This PR implements a new `volume` config where the user can specify the `type` and the `name`of the volume

Valid types are `host`, `csi` and `docker` and the service create a JobSpec mounting it 

`dockerVolume` is deprecated so the user must to use new configuration if want to mount a docker volume

We've agreed only a volume is required, at least by the moment 