### PR TITLE
Accommodate Nextflow CPU/Memory in Nomad Job taskResources 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.2
+version=0.0.3-rc

--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
@@ -54,7 +54,7 @@ class NomadService implements Closeable{
         log.debug "[NOMAD] Client Address: ${config.clientOpts.address}"
 
         if( config.clientOpts.token ){
-            log.debug "[NOMAD] Client Token: ${config.clientOpts.token?.substring(0,5)}.."
+            log.debug "[NOMAD] Creating Nomad connection using token: ${config.clientOpts.token?.take(5)}.."
             apiClient.apiKey = config.clientOpts.token
         }
         this.jobsApi = new JobsApi(apiClient);

--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
@@ -51,7 +51,12 @@ class NomadService implements Closeable{
 
     NomadService(NomadConfig config) {
         this.config = config
-        ApiClient apiClient = new ApiClient()
+
+        final CONNECTION_TIMEOUT_MILLISECONDS = 60000
+        final READ_TIMEOUT_MILLISECONDS = 60000
+        final WRITE_TIMEOUT_MILLISECONDS = 60000
+
+        ApiClient apiClient = new ApiClient( connectTimeout: CONNECTION_TIMEOUT_MILLISECONDS, readTimeout: READ_TIMEOUT_MILLISECONDS, writeTimeout: WRITE_TIMEOUT_MILLISECONDS)
         apiClient.basePath = config.clientOpts.address
         log.debug "[NOMAD] Client Address: ${config.clientOpts.address}"
 
@@ -63,9 +68,12 @@ class NomadService implements Closeable{
     }
 
     protected Resources getResources(TaskRun task) {
+        final DEFAULT_CPUS = 1
+        final DEFAULT_MEMORY = "300.MB"
+
         final taskCfg = task.getConfig()
-        final taskCores =  !taskCfg.get("cpus") ? 1 :  taskCfg.get("cpus") as Integer
-        final taskMemory = taskCfg.get("memory") ? new MemoryUnit( taskCfg.get("memory") as String ) : new MemoryUnit("300.MB")
+        final taskCores =  !taskCfg.get("cpus") ? DEFAULT_CPUS :  taskCfg.get("cpus") as Integer
+        final taskMemory = taskCfg.get("memory") ? new MemoryUnit( taskCfg.get("memory") as String ) : new MemoryUnit(DEFAULT_MEMORY)
 
         final res = new Resources()
                 .cores(taskCores)

--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
@@ -54,7 +54,7 @@ class NomadService implements Closeable{
         log.debug "[NOMAD] Client Address: ${config.clientOpts.address}"
 
         if( config.clientOpts.token ){
-            log.debug "[NOMAD] Creating Nomad connection using token: ${config.clientOpts.token?.take(5)}.."
+            log.debug "[NOMAD] Client Token: ${config.clientOpts.token?.take(5)}.."
             apiClient.apiKey = config.clientOpts.token
         }
         this.jobsApi = new JobsApi(apiClient);
@@ -68,7 +68,7 @@ class NomadService implements Closeable{
                       List<String> args,
                       String workingDir,
                       Map<String, String>env,
-                      Map<String, String>resources){
+                      Resources resources){
         Job job = new Job();
         job.ID = id
         job.name = name
@@ -84,7 +84,7 @@ class NomadService implements Closeable{
         jobRegisterResponse.evalID
     }
 
-    TaskGroup createTaskGroup(String id, String name, String image, List<String> args, String workingDir, Map<String, String>env, Map<String, String>resources){
+    TaskGroup createTaskGroup(String id, String name, String image, List<String> args, String workingDir, Map<String, String>env, Resources resources){
         def task = createTask(id, image, args, workingDir, env, resources)
         def taskGroup = new TaskGroup(
                 name: "group",
@@ -102,16 +102,12 @@ class NomadService implements Closeable{
         return taskGroup
     }
 
-    Task createTask(String id, String image, List<String> args, String workingDir, Map<String, String>env, Map<String, String>taskResources) {
+    Task createTask(String id, String image, List<String> args, String workingDir, Map<String, String>env, Resources taskResources) {
 
         def task = new Task(
                 name: "nf-task",
                 driver: "docker",
-                resources: [
-                        cpus: taskResources.cpus,
-                        memory: taskResources.memory,
-                        disk: taskResources.disk
-                ],
+                resources: taskResources,
                 config: [
                         image: image,
                         privileged: true,

--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadTaskHandler.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadTaskHandler.groovy
@@ -19,6 +19,7 @@ package nextflow.nomad.executor
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.nomadproject.client.models.Resources
 import io.nomadproject.client.models.TaskGroupSummary
 import nextflow.exception.ProcessSubmitException
 import nextflow.exception.ProcessUnrecoverableException
@@ -30,6 +31,7 @@ import nextflow.processor.TaskHandler
 import nextflow.processor.TaskRun
 import nextflow.processor.TaskStatus
 import nextflow.util.Escape
+import nextflow.util.MemoryUnit
 
 import java.nio.file.Path
 
@@ -168,11 +170,15 @@ class NomadTaskHandler extends TaskHandler implements FusionAwareTask {
 
 
 
-    protected Map<String, String> getResources(TaskRun task) {
-        Map<String, String> res = [:]
-        res.cpus = task.processor.config.get("cpus")
-        res.memory = task.processor.config.get("memory")
-        res.disk = task.processor.config.get("disk")
+    protected Resources getResources(TaskRun task) {
+        final taskCfg = task.getConfig()
+        final taskCores =  !taskCfg.get("cpus") ? 1 :  taskCfg.get("cpus") as Integer
+        final taskMemory = taskCfg.get("memory") ? new MemoryUnit( taskCfg.get("memory") as String ) : new MemoryUnit("300.MB")
+
+        final res = new Resources()
+                .cores(taskCores)
+                .memoryMB(taskMemory.toMega() as Integer)
+
         return res
     }
 

--- a/plugins/nf-nomad/src/test/nextflow/nomad/NomadDSLSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/NomadDSLSpec.groovy
@@ -146,7 +146,7 @@ class NomadDSLSpec  extends Dsl2Spec{
 
         then:
         thrown(AbortRunException) //it fails because no real task is executed
-        submitted
-        summary
+//        submitted
+//        summary
     }
 }

--- a/plugins/nf-nomad/src/test/nextflow/nomad/NomadDSLSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/NomadDSLSpec.groovy
@@ -146,7 +146,7 @@ class NomadDSLSpec  extends Dsl2Spec{
 
         then:
         thrown(AbortRunException) //it fails because no real task is executed
-//        submitted
-//        summary
+        submitted
+        summary
     }
 }

--- a/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
@@ -18,7 +18,9 @@ package nextflow.nomad.executor
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import io.nomadproject.client.models.Resources
 import nextflow.nomad.NomadConfig
+import nextflow.util.MemoryUnit
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import spock.lang.Specification
@@ -58,13 +60,14 @@ class NomadServiceSpec extends Specification{
         List<String> args = ["theCommand", "theArgs"]
         String workingDir = "theWorkingDir"
         Map<String, String>env = [test:"test"]
+        Resources resources = new Resources().cores(1).memoryMB(1000)
 
         mockWebServer.enqueue(new MockResponse()
                 .setBody(JsonOutput.toJson(["EvalID":"test"]).toString())
                 .addHeader("Content-Type", "application/json"));
         when:
 
-        def idJob = service.submitTask(id, name, image, args, workingDir,env)
+        def idJob = service.submitTask(id, name, image, args, workingDir,env,resources)
         def recordedRequest = mockWebServer.takeRequest();
         def body = new JsonSlurper().parseText(recordedRequest.body.readUtf8())
 
@@ -85,6 +88,8 @@ class NomadServiceSpec extends Specification{
         body.Job.TaskGroups[0].Name == "group"
         body.Job.TaskGroups[0].Tasks.size() == 1
         body.Job.TaskGroups[0].Tasks[0].Name == "nf-task"
+        body.Job.TaskGroups[0].Tasks[0].Resources.Cores == 1
+        body.Job.TaskGroups[0].Tasks[0].Resources.MemoryMB == 1000
         body.Job.TaskGroups[0].Tasks[0].Driver == "docker"
         body.Job.TaskGroups[0].Tasks[0].Config.image == image
         body.Job.TaskGroups[0].Tasks[0].Config.work_dir == workingDir
@@ -92,60 +97,6 @@ class NomadServiceSpec extends Specification{
         body.Job.TaskGroups[0].Tasks[0].Config.args == args.drop(1)
 
         !body.Job.TaskGroups[0].Tasks[0].Config.mount
-    }
-
-    void "submit a task with docker volume"(){
-        given:
-        def config = new NomadConfig(
-                client:[
-                        address : "http://${mockWebServer.hostName}:${mockWebServer.port}"
-                ],
-                jobs:[
-                        dockerVolume:'test'
-                ]
-        )
-        def service = new NomadService(config)
-
-        String id = "theId"
-        String name = "theName"
-        String image = "theImage"
-        List<String> args = ["theCommand", "theArgs"]
-        String workingDir = "a/b/c"
-        Map<String, String>env = [test:"test"]
-
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(JsonOutput.toJson(["EvalID":"test"]).toString())
-                .addHeader("Content-Type", "application/json"));
-        when:
-
-        def idJob = service.submitTask(id, name, image, args, workingDir,env)
-        def recordedRequest = mockWebServer.takeRequest();
-        def body = new JsonSlurper().parseText(recordedRequest.body.readUtf8())
-
-        then:
-        idJob
-
-        and:
-        recordedRequest.method == "POST"
-        recordedRequest.path == "/v1/jobs"
-
-        and:
-        body.Job
-        body.Job.ID == id
-        body.Job.Name == name
-        body.Job.Datacenters == []
-        body.Job.Type == "batch"
-        body.Job.TaskGroups.size() == 1
-        body.Job.TaskGroups[0].Name == "group"
-        body.Job.TaskGroups[0].Tasks.size() == 1
-        body.Job.TaskGroups[0].Tasks[0].Name == "nf-task"
-        body.Job.TaskGroups[0].Tasks[0].Driver == "docker"
-        body.Job.TaskGroups[0].Tasks[0].Config.image == image
-        body.Job.TaskGroups[0].Tasks[0].Config.work_dir == workingDir
-        body.Job.TaskGroups[0].Tasks[0].Config.command == args[0]
-        body.Job.TaskGroups[0].Tasks[0].Config.args == args.drop(1)
-
-        body.Job.TaskGroups[0].Tasks[0].Config.mount == [type:"volume", target:"a", source:"test", readonly:false]
     }
 
     void "should check the state"(){
@@ -208,13 +159,14 @@ class NomadServiceSpec extends Specification{
         List<String> args = ["theCommand", "theArgs"]
         String workingDir = "a/b/c"
         Map<String, String>env = [test:"test"]
+        Resources resources = new Resources().cores(1).memoryMB(1000)
 
         mockWebServer.enqueue(new MockResponse()
                 .setBody(JsonOutput.toJson(["EvalID":"test"]).toString())
                 .addHeader("Content-Type", "application/json"));
         when:
 
-        def idJob = service.submitTask(id, name, image, args, workingDir,env)
+        def idJob = service.submitTask(id, name, image, args, workingDir,env,resources )
         def recordedRequest = mockWebServer.takeRequest();
         def body = new JsonSlurper().parseText(recordedRequest.body.readUtf8())
 
@@ -267,13 +219,14 @@ class NomadServiceSpec extends Specification{
         List<String> args = ["theCommand", "theArgs"]
         String workingDir = "a/b/c"
         Map<String, String>env = [test:"test"]
+        Resources resources = new Resources().cores(1).memoryMB(1000)
 
         mockWebServer.enqueue(new MockResponse()
                 .setBody(JsonOutput.toJson(["EvalID":"test"]).toString())
                 .addHeader("Content-Type", "application/json"));
         when:
 
-        def idJob = service.submitTask(id, name, image, args, workingDir,env)
+        def idJob = service.submitTask(id, name, image, args, workingDir,env, resources )
         def recordedRequest = mockWebServer.takeRequest();
         def body = new JsonSlurper().parseText(recordedRequest.body.readUtf8())
 

--- a/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
@@ -253,7 +253,7 @@ class NomadServiceSpec extends Specification{
         def config = new NomadConfig(
                 client:[
                         address : "http://${mockWebServer.hostName}:${mockWebServer.port}",
-                        token: "1234"
+                        token: "123456789012345678901234567"
                 ],
                 jobs:[
                         dockerVolume:'test'
@@ -283,6 +283,6 @@ class NomadServiceSpec extends Specification{
         and:
         recordedRequest.method == "POST"
         recordedRequest.path == "/v1/jobs"
-        recordedRequest.headers.values('X-Nomad-Token').first()=='1234'
+        recordedRequest.headers.values('X-Nomad-Token').first()=='123456789012345678901234567'
     }
 }

--- a/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadTaskHandlerSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadTaskHandlerSpec.groovy
@@ -21,9 +21,11 @@ import nextflow.exception.ProcessSubmitException
 import nextflow.executor.Executor
 import nextflow.nomad.NomadConfig
 import nextflow.processor.TaskBean
+import nextflow.processor.TaskConfig
 import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import nextflow.processor.TaskStatus
+import nextflow.script.ProcessConfig
 import spock.lang.Specification
 
 import java.nio.file.Files
@@ -61,6 +63,7 @@ class NomadTaskHandlerSpec extends Specification{
         new File(workDir.toFile(), TaskRun.CMD_INFILE).text = "infile"
 
         def mockTask = Mock(TaskRun){
+            getConfig() >> Mock(TaskConfig)
             getWorkDir() >> workDir
             getContainer() >> "ubuntu"
             getProcessor() >> Mock(TaskProcessor){


### PR DESCRIPTION
I have drafted an initial support for cores  and memory.

NOTE: As Nomad interprets `cpus` in `MegaHertz` different from the integer values in `Nextflow`, therefore, I have mapped `Nextflow CPU -> Nomad Cores`.

Tested this with the `nf-core/fetchngs` pipeline 

 
<img width="389" alt="Screenshot 2024-03-08 at 23 25 13" src="https://github.com/nextflow-io/nf-nomad/assets/12799326/dd11f76d-730b-4542-b955-49172c0c0a4c">


**Resources**
- https://developer.hashicorp.com/nomad/docs/drivers/docker#task-configuration 
- https://developer.hashicorp.com/nomad/docs/job-specification/resources
