### PR TITLE
add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ sun-nomadlab
 .project
 .classpath
 .settings
+/validation/nomad_temp/**
+/validation/nomad

--- a/validation/README.md
+++ b/validation/README.md
@@ -16,7 +16,7 @@ cd validation
 sudo ./start-nomad.sh
 ```
 
-`sudo` is required as the client needs to mount a folder as shared volumen
+`sudo` is required as the client needs to mount a folder as shared volume
 
 Basically this command create a `nomad_temp` folder, run a server and a client, and mount `nomad_temp/scratchdir` as a `local` volume
 , so all pipelines can/must use it as working dir 

--- a/validation/README.md
+++ b/validation/README.md
@@ -50,7 +50,7 @@ so Nextflow will use the compiled version
   } 
 ```
 
-the executor will mount the `scracthdir` volume configured by the `start-nomad.sh` command 
+the executor will mount the `scratchdir` volume configured by the `start-nomad.sh` command 
 
 
 ### Bactopia

--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,83 @@
+# Validation tests
+
+Before to run the validation tests you must to "recompile" the plugin using `latest` version:
+
+`./gradlew clean unzipPlugin -P version=latest`
+
+this command will build and install current code of the plugin with the version name `latest` used by this validation
+tests
+
+## Start a cluster
+
+open a terminal a execute
+
+```shell
+cd validation
+sudo ./start-nomad.sh
+```
+
+`sudo` is required as the client needs to mount a folder as shared volumen
+
+Basically this command create a `nomad_temp` folder, run a server and a client, and mount `nomad_temp/scratchdir` as a `local` volume
+, so all pipelines can/must use it as working dir 
+
+## Run pipelines examples
+
+open another terminal and execute:
+
+### Hello
+
+```shell
+cd validation
+./run-pipeline.sh -c basic/nextflow.config ./basic/main.nf 
+```
+
+this command will launch the `hello` nextflow pipeline using the `nomad` executor. 
+
+The most important part of the configuration (`basic/nextflow.config`) are:
+
+``` 
+plugins {
+    id 'nf-nomad@latest'
+}
+```
+
+so Nextflow will use the compiled version
+
+```
+  jobs {
+        volume = { type "host" name "scratchdir" }
+  } 
+```
+
+the executor will mount the `scracthdir` volume configured by the `start-nomad.sh` command 
+
+
+### Bactopia
+
+A more elaborate example:
+
+```shell
+cd validation
+./run-pipeline.sh bactopia/bactopia \
+  -c basic/nextflow.config \
+  -profile test,docker \
+  --outdir $(pwd)/nomad_temp/scratchdir/out \
+  --accession SRX4563634     \
+  --coverage 100     \
+  --genome_size 2800000     \
+  --max_cpus 2 \
+  --datasets_cache $(pwd)/nomad_temp/scratchdir/cache
+```
+
+See how we set the `datasets_cache` params, so it'll use the shared volume
+
+
+## Stop the cluster
+
+```shell
+cd validation
+sudo ./stop-nomad.sh
+```
+
+This command try to clean and kill the nomad process unmounting temp folders created by the client

--- a/validation/basic/main.nf
+++ b/validation/basic/main.nf
@@ -1,0 +1,18 @@
+#!/usr/bin/env nextflow
+
+process sayHello {
+    container   'ubuntu:20.04'
+
+    input:
+    val x
+    output:
+    stdout
+    script:
+    """
+    echo '$x world!'
+    """
+}
+
+workflow {
+    Channel.of('Bonjour', 'Ciao', 'Hello', 'Hola') | sayHello | view
+}

--- a/validation/basic/nextflow.config
+++ b/validation/basic/nextflow.config
@@ -1,0 +1,20 @@
+plugins {
+    id 'nf-nomad@latest'
+}
+
+process {
+    executor = "nomad"
+}
+
+nomad {
+
+    client {
+        address = "http://localhost:4646"
+    }
+
+    jobs {
+        deleteOnCompletion = false
+        volume = { type "host" name "scratchdir" }
+    }
+
+}

--- a/validation/client.conf
+++ b/validation/client.conf
@@ -1,0 +1,27 @@
+
+bind_addr = "0.0.0.0" # the default
+
+plugin "docker" {
+  config {
+    allow_privileged = true
+    volumes{
+        enabled = true
+    }
+    gc {
+      image = false
+      image_delay = "1h"
+    }
+  }
+}
+
+client {
+  enabled = true
+  node_class = "node"
+  server_join {
+    retry_join = [
+      "localhost"
+    ]
+    retry_max = 3
+    retry_interval = "15s"
+  }
+}

--- a/validation/run-pipeline.sh
+++ b/validation/run-pipeline.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./wait-nomad.sh
+
+NXF_ASSETS=$(pwd)/nomad_temp/scratchdir/assets \
+  NXF_CACHE_DIR=$(pwd)/nomad_temp/scratchdir/cache \
+    nextflow run -w $(pwd)/nomad_temp/scratchdir/ "$@"

--- a/validation/server.conf
+++ b/validation/server.conf
@@ -1,0 +1,8 @@
+
+bind_addr = "0.0.0.0" # the default
+
+server {
+  enabled          = true
+  bootstrap_expect = 1
+}
+

--- a/validation/start-nomad.sh
+++ b/validation/start-nomad.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+mkdir -p nomad_temp
+cd nomad_temp
+
+CURRENT_DIR=$(pwd)
+
+mkdir -p client -p server -p scratchdir
+chmod ugoa+rw -R scratchdir
+
+rm -f server-custom.conf
+cat >server-custom.conf <<EOL
+data_dir  = "${CURRENT_DIR}/server"
+EOL
+
+rm -f client-custom.conf
+cat >client-custom.conf <<EOL
+data_dir  = "${CURRENT_DIR}/client"
+
+client{
+    host_volume "scratchdir" {
+      path      = "${CURRENT_DIR}/scratchdir"
+      read_only = false
+    }
+}
+EOL
+
+cp ../server.conf .
+cp ../client.conf .
+../nomad agent -config server.conf -config client.conf -config server-custom.conf -config client-custom.conf

--- a/validation/stop-nomad.sh
+++ b/validation/stop-nomad.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+./nomad node drain -enable $(./nomad node status -quiet)
+./nomad system gc
+sleep 1
+df -h --output=target | grep nf-task | xargs sudo umount
+pkill -9 nomad

--- a/validation/wait-nomad.sh
+++ b/validation/wait-nomad.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+until curl --output /dev/null --silent --head --fail http://localhost:4646; do
+    printf '.'
+    sleep 5
+done
+
+./nomad node drain -disable $(./nomad node status -quiet)
+sleep 3


### PR DESCRIPTION
This is a first proposal about how to run "integration" tests

Basically it uses a couple of bash to prepare and run a local server+client mounting a folder as a volume so we can run basic pipelines to validate them against last version of the plugin


closes #35