### PR TITLE
implementation of possibility to add multiple volumes

### DIFF
--- a/plugins/nf-nomad/src/main/nextflow/nomad/config/VolumeSpec.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/config/VolumeSpec.groovy
@@ -1,7 +1,5 @@
 package nextflow.nomad.config
 
-import nextflow.nomad.NomadConfig
-
 class VolumeSpec {
 
     final static public String VOLUME_DOCKER_TYPE = "docker"
@@ -14,6 +12,8 @@ class VolumeSpec {
 
     private String type
     private String name
+    private String path
+    private boolean workDir = false
 
     String getType() {
         return type
@@ -21,6 +21,14 @@ class VolumeSpec {
 
     String getName() {
         return name
+    }
+
+    boolean getWorkDir() {
+        return workDir
+    }
+
+    String getPath() {
+        return path
     }
 
     VolumeSpec type(String type){
@@ -33,12 +41,25 @@ class VolumeSpec {
         this
     }
 
+    VolumeSpec workDir(boolean b){
+        this.workDir = b
+        this
+    }
+
+    VolumeSpec path(String path){
+        this.path = path
+        this
+    }
+
     void validate(){
         if( !VOLUME_TYPES.contains(type) ) {
             throw new IllegalArgumentException("Volume type $type is not supported")
         }
         if( !this.name ){
-            throw new IllegalArgumentException("Volume name is required")
+            throw new IllegalArgumentException("Volume name is required (type $type)")
+        }
+        if( !this.workDir && !this.path ){
+            throw new IllegalArgumentException("Volume path is required in secondary volumes")
         }
     }
 }

--- a/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
@@ -372,9 +372,9 @@ class NomadServiceSpec extends Specification{
         body.Job.TaskGroups[0].Tasks[0].Config.args == args.drop(1)
 
         body.Job.TaskGroups[0].Volumes.size() == 1
-        body.Job.TaskGroups[0].Volumes['test'] == [AccessMode:"multi-node-multi-writer", AttachmentMode:"file-system", Source:"test", Type:"csi"]
+        body.Job.TaskGroups[0].Volumes['vol_0'] == [AccessMode:"multi-node-multi-writer", AttachmentMode:"file-system", Source:"test", Type:"csi"]
         body.Job.TaskGroups[0].Tasks[0].VolumeMounts.size() == 1
-        body.Job.TaskGroups[0].Tasks[0].VolumeMounts[0] == [Destination:"/a", Volume:"test"]
+        body.Job.TaskGroups[0].Tasks[0].VolumeMounts[0] == [Destination:"/a", Volume:"vol_0"]
 
     }
 

--- a/validation/multiple-volumes/2-volumes.config
+++ b/validation/multiple-volumes/2-volumes.config
@@ -1,0 +1,23 @@
+plugins {
+    id 'nf-nomad@latest'
+}
+
+process {
+    executor = "nomad"
+}
+
+nomad {
+
+    client {
+        address = "http://localhost:4646"
+    }
+
+    jobs {
+        deleteOnCompletion = false
+        volumes = [
+            { type "host" name "scratchdir" },
+            { type "host" name "scratchdir" path "/var/data" },  // can mount same volume in different path
+        ]
+    }
+
+}

--- a/validation/multiple-volumes/3-volumes.config
+++ b/validation/multiple-volumes/3-volumes.config
@@ -1,0 +1,26 @@
+plugins {
+    id 'nf-nomad@latest'
+}
+
+process {
+    executor = "nomad"
+}
+
+nomad {
+
+    client {
+        address = "http://localhost:4646"
+    }
+
+    jobs {
+        deleteOnCompletion = false
+
+        volume = { type "host" name "scratchdir" }
+
+        volumes = [
+            { type "host" name "scratchdir" path "/var/data1" },
+            { type "host" name "scratchdir" path "/var/data2" }
+        ]
+    }
+
+}

--- a/validation/multiple-volumes/main.nf
+++ b/validation/multiple-volumes/main.nf
@@ -1,0 +1,18 @@
+#!/usr/bin/env nextflow
+
+process sayHello {
+    container   'ubuntu:20.04'
+
+    input:
+    val x
+    output:
+    stdout
+    script:
+    """
+    echo '$x world!'
+    """
+}
+
+workflow {
+    Channel.of('Bonjour', 'Ciao', 'Hello', 'Hola') | sayHello | view
+}


### PR DESCRIPTION
This implementation introduces a new config `volumes` (plural) as a List of VolumeSpec closures

Tested against the validation folder:

```
 jobs {
        volume = { type "host" name "scratchdir" }

        volumes = [
            { type "host" name "scratchdir" path "/var/data1" },
            { type "host" name "scratchdir" path "/var/data2" }
        ]
    }
```

- you can use `volume` , `volumes` or a mix of both
- you can/need to specify the path in "secondary" volumes
- you can specify which volume uses as workDir (so path is not required)

closes #45