### PR TITLE
run e2e tests in local and/or remote

### DIFF
--- a/plugins/nf-nomad/build.gradle
+++ b/plugins/nf-nomad/build.gradle
@@ -108,7 +108,7 @@ jar {
                 'Plugin-Version': archiveVersion,
                 'Plugin-Class': "nextflow.nomad.NomadPlugin",
                 'Plugin-Provider': 'nextflow',
-                'Plugin-Requires': '>=23.10.0',
+                'Plugin-Requires': '>=24.04.0',
         )
     }
 }

--- a/validation/README.md
+++ b/validation/README.md
@@ -7,9 +7,9 @@ Before to run the validation tests you must to "recompile" the plugin using `lat
 this command will build and install current code of the plugin with the version name `latest` used by this validation
 tests
 
-## Start a cluster
+## Start a local "cluster"
 
-open a terminal a execute
+open a terminal an execute
 
 ```shell
 cd validation
@@ -53,24 +53,36 @@ so Nextflow will use the compiled version
 the executor will mount the `scratchdir` volume configured by the `start-nomad.sh` command 
 
 
-### Bactopia
+### Test pipelines
 
-A more elaborate example:
+You can run a set of predefined pipelines as `hello`, `nf-core/demo`, etc:
 
-```shell
-cd validation
-./run-pipeline.sh bactopia/bactopia \
-  -c basic/nextflow.config \
-  -profile test,docker \
-  --outdir $(pwd)/nomad_temp/scratchdir/out \
-  --accession SRX4563634     \
-  --coverage 100     \
-  --genome_size 2800000     \
-  --max_cpus 2 \
-  --datasets_cache $(pwd)/nomad_temp/scratchdir/cache
-```
+In a terminal run `./run-all.sh`
 
-See how we set the `datasets_cache` params, so it'll use the shared volume
+this command will run all these pipelines against your local cluster
+
+__You can force to rebuild latest version of the plugins with the `--build` argument__
+
+__You can skip local tests with `--skiplocal` argument__
+
+### Test remote cluster
+
+We've created a cluster with 3 nodes in azure called `nfazure` and, if you have access to it, 
+you can test some pipelines from your terminal using the `--nfazure` argument
+
+(`--nfazure` will scp the `az-nomadlab` directory and execute different pipelines using ssh remote command)
+
+### Examples
+
+- `./run-all.sh` use current last version and run pipelines using local cluster
+
+- `./run-all.sh --build --skiplocal` build and deploy last version
+
+- `./run-all.sh --nfazure` run local and remote pipelines
+
+- `./run-all.sh --skiplocal --nfazure` run only remote pipelines
+
+
 
 
 ## Stop the cluster

--- a/validation/az-nomadlab/nextflow.config
+++ b/validation/az-nomadlab/nextflow.config
@@ -1,0 +1,25 @@
+plugins {
+    id 'nf-nomad@latest'
+}
+
+process {
+    executor = "nomad"
+}
+
+nomad {
+
+     client {
+         address = "http://10.0.2.6:4646"
+     }
+
+     jobs {
+         deleteOnCompletion = false
+         namespace = "nf"
+         volumes = [ 
+		{ type "csi" 
+		  name "nextflow-fs-volume" 
+		}
+	 ]
+     }
+
+}

--- a/validation/run-all.sh
+++ b/validation/run-all.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+BUILD=0
+SKIPLOCAL=0
+NFAZURE=0
+
+[[ "$@" =~ '--build' ]] && BUILD=1
+[[ -f $HOME/.nextflow/plugins/nf-nomad-latest/ ]]  && BUILD=1
+[[ "$@" =~ '--skiplocal' ]] && SKIPLOCAL=1
+[[ "$@" =~ '--nfazure' ]] && NFAZURE=1
+
+if [ "$BUILD" == 1 ]; then
+  pushd ..
+  ./gradlew unzipPlugin -x test -P version=latest
+  popd +0  || exit
+else
+  echo "skip build"
+fi
+
+if [ "$SKIPLOCAL" == 0 ]; then
+
+  ./run-pipeline.sh -c basic/nextflow.config basic/main.nf
+
+  ./run-pipeline.sh -c basic/nextflow.config nf-core/demo \
+    -r dev -profile test,docker \
+    --outdir $(pwd)/nomad_temp/scratchdir/out
+
+  ./run-pipeline.sh -c basic/nextflow.config bactopia/bactopia \
+    --accession SRX4563634 --coverage 100 --genome_size 2800000 \
+    -profile test,docker --outdir $(pwd)/nomad_temp/scratchdir/bactopia/outdir \
+    --datasets_cache $(pwd)/nomad_temp/scratchdir/bactopia/datasets
+
+else
+  echo "skip local"
+fi
+
+if [ "$NFAZURE" == 1 ]; then
+  ssh manager@nfazure 'rm -rf ~/.nextflow/plugins/nf-nomad-latest'
+  rsync -Pr ~/.nextflow/plugins/nf-nomad-latest manager@nfazure:~/.nextflow/plugins/
+  rsync -Pr az-nomadlab manager@nfazure:~/integration-tests/
+
+  ssh manager@nfazure \
+    'cd ~/integration-tests/az-nomadlab; NXF_ASSETS=/projects/assets nextflow run hello -w /projects/ -c nextflow.config'
+
+  ssh manager@nfazure \
+    'cd ~/integration-tests/az-nomadlab; NXF_ASSETS=/projects/assets nextflow run bactopia/bactopia -c nextflow.config -w /projects -profile test,docker --outdir /projects/bactopia/outdir --accession SRX4563634 --coverage 100 --genome_size 2800000 --datasets_cache /projects/bactopia/datasets'
+else
+  echo "skip nfazure"
+fi

--- a/validation/start-nomad.sh
+++ b/validation/start-nomad.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if [ ! -f ./nomad ]; then
+  curl -O https://releases.hashicorp.com/nomad/1.7.3/nomad_1.7.3_linux_amd64.zip
+  unzip nomad_1.7.3_linux_amd64.zip
+  rm -f nomad_1.7.3_linux_amd64.zip
+fi
 
 mkdir -p nomad_temp
 cd nomad_temp

--- a/validation/start-nomad.sh
+++ b/validation/start-nomad.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
+set -uex
+
+export NOMAD_VERSION="1.8.1"
+export NOMAD_PLATFORM="linux_amd64"
+
 if [ ! -f ./nomad ]; then
-  curl -O https://releases.hashicorp.com/nomad/1.7.3/nomad_1.7.3_linux_amd64.zip
-  unzip nomad_1.7.3_linux_amd64.zip
-  rm -f nomad_1.7.3_linux_amd64.zip
+  curl -O "https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${NOMAD_PLATFORM}.zip"
+  unzip nomad_${NOMAD_VERSION}_${NOMAD_PLATFORM}.zip
+  rm -f nomad_${NOMAD_VERSION}_${NOMAD_PLATFORM}.zip
 fi
 
 mkdir -p nomad_temp


### PR DESCRIPTION
this PR improve the end 2 end tests so you can run a set of pipelines in local or remote

you need to share your keys with the remote nf-azure server in order to be able to run ssh commands without password

the run-all.sh build and copy current version of the plugin as `latest` in the remote server

closes #51 