### PR TITLE
create a secured cluster with ACL for validation

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -21,6 +21,9 @@ sudo ./start-nomad.sh
 Basically this command create a `nomad_temp` folder, run a server and a client, and mount `nomad_temp/scratchdir` as a `local` volume
 , so all pipelines can/must use it as working dir 
 
+Use `--secure` argument if you want to create a secured cluster. The script will bootstrap an ACL and a NOMAD_TOKEN
+will be generated (see the output of the script)
+
 ## Run pipelines examples
 
 open another terminal and execute:

--- a/validation/wait-nomad.sh
+++ b/validation/wait-nomad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-until curl --output /dev/null --silent --head --fail http://localhost:4646; do
+until curl --output /dev/null --silent --fail http://localhost:4646/v1/status/leader; do
     printf '.'
     sleep 5
 done


### PR DESCRIPTION
If you provide the `--secure` argument when creating the local cluster the script will initialize it using ACL

The management token will be showed by console. You need to provide this token (i.e. NOMAD_TOKEN env) to run the pipeline

