### PR TITLE
allow to set a volume as readOnly (apply only in csi driver)

### DIFF
--- a/plugins/nf-nomad/src/main/nextflow/nomad/config/VolumeSpec.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/config/VolumeSpec.groovy
@@ -35,6 +35,7 @@ class VolumeSpec {
     private String name
     private String path
     private boolean workDir = false
+    private boolean readOnly = false
 
     String getType() {
         return type
@@ -50,6 +51,10 @@ class VolumeSpec {
 
     String getPath() {
         return path
+    }
+
+    boolean getReadOnly(){
+        return readOnly
     }
 
     VolumeSpec type(String type){
@@ -72,6 +77,29 @@ class VolumeSpec {
         this
     }
 
+    VolumeSpec readOnly(boolean readOnly){
+        this.readOnly = readOnly
+        this
+    }
+
+    String getAccessMode(){
+        return switch (this.type){
+            case VOLUME_CSI_TYPE->
+                readOnly ?
+                        "multi-node-reader-only"
+                        :
+                        "multi-node-multi-writer";
+            default -> ""
+        }
+    }
+
+    String getAttachmentMode(){
+        return switch (this.type){
+            case VOLUME_CSI_TYPE->"file-system";
+            default -> ""
+        }
+    }
+
     void validate(){
         if( !VOLUME_TYPES.contains(type) ) {
             throw new IllegalArgumentException("Volume type $type is not supported")
@@ -81,6 +109,9 @@ class VolumeSpec {
         }
         if( !this.workDir && !this.path ){
             throw new IllegalArgumentException("Volume path is required in secondary volumes")
+        }
+        if( this.workDir && this.readOnly ){
+            throw new IllegalArgumentException("WorkingDir Volume can't be readOnly")
         }
     }
 }

--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadService.groovy
@@ -139,8 +139,9 @@ class NomadService implements Closeable{
                     taskGroup.volumes["vol_${idx}".toString()] = new VolumeRequest(
                             type: volumeSpec.type,
                             source: volumeSpec.name,
-                            attachmentMode: "file-system",
-                            accessMode: "multi-node-multi-writer"
+                            attachmentMode: volumeSpec.attachmentMode,
+                            accessMode: volumeSpec.accessMode,
+                            readOnly: volumeSpec.readOnly,
                     )
                 }
 
@@ -148,6 +149,7 @@ class NomadService implements Closeable{
                     taskGroup.volumes["vol_${idx}".toString()] = new VolumeRequest(
                             type: volumeSpec.type,
                             source: volumeSpec.name,
+                            readOnly: volumeSpec.readOnly,
                     )
                 }
             }
@@ -326,6 +328,9 @@ class NomadService implements Closeable{
     String getClientOfJob(String jobId) {
         try{
             List<AllocationListStub> allocations = jobsApi.getJobAllocations(jobId, config.jobOpts().region, config.jobOpts().namespace, null, null, null, null, null, null, null, null)
+            if( !allocations ){
+                return null
+            }
             AllocationListStub jobAllocation = allocations.first()
             return jobAllocation.nodeName
         }catch (Exception e){

--- a/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/executor/NomadServiceSpec.groovy
@@ -370,7 +370,7 @@ class NomadServiceSpec extends Specification{
         body.Job.TaskGroups[0].Tasks[0].Config.args == args.drop(1)
 
         body.Job.TaskGroups[0].Volumes.size() == 1
-        body.Job.TaskGroups[0].Volumes['vol_0'] == [AccessMode:"multi-node-multi-writer", AttachmentMode:"file-system", Source:"test", Type:"csi"]
+        body.Job.TaskGroups[0].Volumes['vol_0'] == [AccessMode:"multi-node-multi-writer", AttachmentMode:"file-system", Source:"test", Type:"csi", ReadOnly:false]
         body.Job.TaskGroups[0].Tasks[0].VolumeMounts.size() == 1
         body.Job.TaskGroups[0].Tasks[0].VolumeMounts[0] == [Destination:"/a", Volume:"vol_0"]
 

--- a/validation/az-nomadlab/2-volumes.config
+++ b/validation/az-nomadlab/2-volumes.config
@@ -1,0 +1,23 @@
+plugins {
+    id 'nf-nomad@latest'
+}
+
+process {
+    executor = "nomad"
+}
+
+nomad {
+
+    client {
+     address = "http://10.0.2.6:4646"
+    }
+
+    jobs {
+         deleteOnCompletion = false
+         namespace = "nf"
+         volumes = [
+            { type "csi" name "nextflow-fs-volume" },
+            { type "csi" name "nextflow-fs-volume" path "/var/data" readOnly true}
+	    ]
+    }
+}

--- a/validation/run-all.sh
+++ b/validation/run-all.sh
@@ -25,6 +25,12 @@ if [ "$SKIPLOCAL" == 0 ]; then
 
   ./run-pipeline.sh -c basic/nextflow.config basic/main.nf
 
+  ./run-pipeline.sh -c directives/nextflow.config directives/main.nf
+
+  ./run-pipeline.sh -c multiple-volumes/2-volumes.config multiple-volumes/main.nf
+
+  ./run-pipeline.sh -c multiple-volumes/3-volumes.config multiple-volumes/main.nf
+
   ./run-pipeline.sh -c basic/nextflow.config nf-core/demo \
     -r dev -profile test,docker \
     --outdir $(pwd)/nomad_temp/scratchdir/out
@@ -45,6 +51,9 @@ if [ "$NFAZURE" == 1 ]; then
 
   ssh manager@nfazure \
     'cd ~/integration-tests/az-nomadlab; NXF_ASSETS=/projects/assets nextflow run hello -w /projects/ -c nextflow.config'
+
+  ssh manager@nfazure \
+    'cd ~/integration-tests/az-nomadlab; NXF_ASSETS=/projects/assets nextflow run hello -w /projects/ -c 2-volumes.config'
 
   ssh manager@nfazure \
     'cd ~/integration-tests/az-nomadlab; NXF_ASSETS=/projects/assets nextflow run bactopia/bactopia -c nextflow.config -w /projects -profile test,docker --outdir /projects/bactopia/outdir --accession SRX4563634 --coverage 100 --genome_size 2800000 --datasets_cache /projects/bactopia/datasets'


### PR DESCRIPTION
Add a readOnly method in the VolumeSpec

apply only in `csi` drivers

Tested against of our nfazure, setting secondary volume as readOnly:

```
"Volumes": {
        "vol_1": {
          "Name": "",
          "Type": "csi",
          "Source": "nextflow-fs-volume",
          "ReadOnly": true,
          "AccessMode": "multi-node-reader-only",
          "AttachmentMode": "file-system",
          "MountOptions": null,
          "PerAlloc": false
        },
        "vol_0": {
          "Name": "",
          "Type": "csi",
          "Source": "nextflow-fs-volume",
          "ReadOnly": false,
          "AccessMode": "multi-node-multi-writer",
          "AttachmentMode": "file-system",
          "MountOptions": null,
          "PerAlloc": false
        }
```


closes #60