### PR TITLE
integration test in sun-nomadlab 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ out
 
 _resources
 oracle-nomad-cluster
-sun-nomadlab
 
 .project
 .classpath

--- a/validation/run-all.sh
+++ b/validation/run-all.sh
@@ -62,17 +62,19 @@ else
 fi
 
 
-#NOTE: In this use-case, the default login user is not a sudoer.
+#NOTE: In this use-case you need to be in the same network of sun-nomadlab server, for example using a tailscale connection
+#NOTE2: You need to have 2 secrets stored in your Nextlow: SUN_NOMADLAB_ACCESS_KEY and SUN_NOMADLAB_SECRET_KEY
 if [ "$NFSUN" == 1 ]; then
-  ssh nomad01 'rm -rf ~/.nextflow/plugins/nf-nomad-latest'
-  rsync -Pr ~/.nextflow/plugins/nf-nomad-latest nomad01:~/.nextflow/plugins/
-  rsync -Pr sun-nomadlab nomad01:~/integration-tests/
 
-  ssh nomad01 \
-    'cd ~/integration-tests/sun-nomadlab; NXF_ASSETS=~/abhinav/jfs/nomad/projects/assets nextflow run hello -w ~/abhinav/jfs/nomad/workdir -c ~/integration-tests/sun-nomadlab/nextflow.config'
+ nextflow run -w s3://juicefs/integration-test -c sun-nomadlab/nextflow.config hello
 
-#  ssh nomad01 \
-#    'cd ~/integration-tests/sun-nomadlab; NXF_ASSETS=/projects/assets nextflow run bactopia/bactopia -c nextflow.config -w /projects -profile test,docker --outdir /projects/bactopia/outdir --accession SRX4563634 --coverage 100 --genome_size 2800000 --datasets_cache /projects/bactopia/datasets'
+ NXF_ASSETS=s3://juicefs/assets nextflow run bactopia/bactopia \
+    -w s3://juicefs/integration-test -c sun-nomadlab/nextflow.config \
+    -profile test,docker --outdir s3://juicefs/bactopia/outdir \
+    --accession SRX4563634 --coverage 100 --genome_size 2800000 \
+    --datasets_cache s3://juicefs/bactopia/assets
+
+
 else
   echo "skip nfsun"
 fi

--- a/validation/run-all.sh
+++ b/validation/run-all.sh
@@ -68,7 +68,7 @@ if [ "$NFSUN" == 1 ]; then
 
  nextflow run -w s3://juicefs/integration-test -c sun-nomadlab/nextflow.config hello
 
- NXF_ASSETS=s3://juicefs/assets nextflow run bactopia/bactopia \
+ nextflow run bactopia/bactopia \
     -w s3://juicefs/integration-test -c sun-nomadlab/nextflow.config \
     -profile test,docker --outdir s3://juicefs/bactopia/outdir \
     --accession SRX4563634 --coverage 100 --genome_size 2800000 \

--- a/validation/sun-nomadlab/nextflow.config
+++ b/validation/sun-nomadlab/nextflow.config
@@ -1,0 +1,38 @@
+plugins {
+    id 'nf-nomad@latest'
+}
+
+process {
+    executor = "nomad"
+}
+
+aws {
+    accessKey = secrets.SUN_NOMADLAB_ACCESS_KEY
+    secretKey = secrets.SUN_NOMADLAB_SECRET_KEY
+    client {
+        endpoint = 'http://100.119.165.23:9000'
+    }
+}
+
+wave {
+  enabled = true
+}
+
+fusion {
+  enabled = true
+  exportStorageCredentials = true
+}
+
+nomad {
+
+    client {
+     address = 'http://100.119.165.23:4646'
+    }
+
+    jobs {
+         deleteOnCompletion = true
+         volumes = [
+            { type "csi" name "juicefs-volume" }
+	    ]
+    }
+}


### PR DESCRIPTION
Refactor of the sun-nomadlab integration tests

no ssh required, only to be in the same network of the nomad server (request tailscale access to @abhi18av )

also you need to add 2 secrets into your nextflow vault (see instructions in `run-all.sh`) to access the minio filesystem