### PR TITLE
Add sleep and nf-core/demo pipelines for sun-nomadlab

### DIFF
--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadTaskHandler.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadTaskHandler.groovy
@@ -200,7 +200,7 @@ class NomadTaskHandler extends TaskHandler implements FusionAwareTask {
             exitFile.text as Integer
         }
         catch (Exception e) {
-            log.debug "[NOMAD] Cannot read exit status for task: `$task.name` | ${e.message}"
+            log.warn "[NOMAD] Cannot read exit status for task: `$task.name` | ${e.message}"
             return Integer.MAX_VALUE
         }
     }
@@ -217,7 +217,7 @@ class NomadTaskHandler extends TaskHandler implements FusionAwareTask {
                 clientName = nomadService.getClientOfJob( jobName )
             log.debug "[NOMAD] determineClientNode: jobName:$jobName; clientName:$clientName"
         } catch ( Exception e ){
-            log.warn ("[NOMAD] Unable to get the client name of job $jobName -- see the log file for details", e)
+            log.debug ("[NOMAD] Unable to get the client name of job $jobName -- awaiting for a client to be assigned.")
         }
     }
 

--- a/validation/run-all.sh
+++ b/validation/run-all.sh
@@ -6,12 +6,16 @@ BUILD=0
 SKIPLOCAL=0
 NFAZURE=0
 NFSUN=0
+NFSLEEP=0
+NFDEMO=0
 
 [[ "$@" =~ '--build' ]] && BUILD=1
 [[ -f $HOME/.nextflow/plugins/nf-nomad-latest/ ]]  && BUILD=1
 [[ "$@" =~ '--skiplocal' ]] && SKIPLOCAL=1
 [[ "$@" =~ '--nfazure' ]] && NFAZURE=1
 [[ "$@" =~ '--nfsun' ]] && NFSUN=1
+[[ "$@" =~ '--sleep' ]] && NFSLEEP=1
+[[ "$@" =~ '--demo' ]] && NFDEMO=1
 
 if [ "$BUILD" == 1 ]; then
   pushd ..
@@ -66,14 +70,22 @@ fi
 #NOTE2: You need to have 2 secrets stored in your Nextlow: SUN_NOMADLAB_ACCESS_KEY and SUN_NOMADLAB_SECRET_KEY
 if [ "$NFSUN" == 1 ]; then
 
- nextflow run -w s3://juicefs/integration-test -c sun-nomadlab/nextflow.config hello
+ if [ "$NFSLEEP" == 1 ]; then 
+   nextflow run -w s3://fusionfs/integration-test/work -c sun-nomadlab/nextflow.config abhi18av/nf-sleep --timeout 360
 
- nextflow run bactopia/bactopia \
-    -w s3://juicefs/integration-test -c sun-nomadlab/nextflow.config \
-    -profile test,docker --outdir s3://juicefs/bactopia/outdir \
-    --accession SRX4563634 --coverage 100 --genome_size 2800000 \
-    --datasets_cache s3://juicefs/bactopia/assets
+ elif [ "$NFDEMO" == 1 ]; then
+   nextflow run nf-core/demo \
+      -w s3://fusionfs/integration-test/work -c sun-nomadlab/nextflow.config \
+      -profile test,docker --outdir s3://fusionfs/integration-test/nf-core-demo/outdir
+ else
+   nextflow run -w s3://fusionfs/integration-test/work -c sun-nomadlab/nextflow.config hello
 
+   nextflow run bactopia/bactopia \
+      -w s3://fusionfs/integration-test/work -c sun-nomadlab/nextflow.config \
+      -profile test,docker --outdir s3://fusionfs/integration-test/bactopia/outdir \
+      --accession SRX4563634 --coverage 100 --genome_size 2800000 \
+      --datasets_cache s3://fusionfs/integration-test/bactopia/assets
+ fi
 
 else
   echo "skip nfsun"

--- a/validation/sun-nomadlab/nextflow.config
+++ b/validation/sun-nomadlab/nextflow.config
@@ -30,7 +30,7 @@ nomad {
     }
 
     jobs {
-         deleteOnCompletion = true
+         deleteOnCompletion = false
          volumes = [
             { type "csi" name "juicefs-volume" }
 	    ]


### PR DESCRIPTION
This PR builds upon the work done in https://github.com/nextflow-io/nf-nomad/pull/64 and focuses on using the `sun-nomadlab` cluster for purely `fusionfs` based setup.


