### PR TITLE
generate a random jobName in case job.hash is null

### DIFF
--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadTaskHandler.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/NomadTaskHandler.groovy
@@ -131,7 +131,8 @@ class NomadTaskHandler extends TaskHandler implements FusionAwareTask {
         def builder = createBashWrapper(task)
         builder.build()
 
-        this.jobName = NomadHelper.sanitizeName(task.hash?.toString() + "-" + task.name)
+        def hash = task.hash?.toString() ?: UUID.randomUUID().toString()
+        this.jobName = NomadHelper.sanitizeName(hash + "-" + task.name)
 
         final taskLauncher = getSubmitCommand(task)
         final taskEnv = getEnv(task)


### PR DESCRIPTION
it seems in some situation the hash for the task is not assigned

For this situation we'll use a random UUID to be sure every task as an unique job ID