### PR TITLE
add spread feature

### DIFF
--- a/plugins/nf-nomad/src/main/nextflow/nomad/config/NomadJobOpts.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/config/NomadJobOpts.groovy
@@ -22,6 +22,7 @@ import groovy.util.logging.Slf4j
 import nextflow.nomad.models.JobAffinity
 import nextflow.nomad.models.JobConstraint
 import nextflow.nomad.models.JobConstraints
+import nextflow.nomad.models.JobSpreads
 import nextflow.nomad.models.JobVolume
 
 
@@ -45,6 +46,7 @@ class NomadJobOpts{
     JobAffinity affinitySpec
     JobConstraint constraintSpec
     JobConstraints constraintsSpec
+    JobSpreads spreadsSpec
 
     Integer rescheduleAttempts
     Integer restartAttempts
@@ -85,6 +87,7 @@ class NomadJobOpts{
         this.constraintSpec = parseConstraint(nomadJobOpts)
         this.constraintsSpec = parseConstraints(nomadJobOpts)
         this.secretOpts = parseSecrets(nomadJobOpts)
+        this.spreadsSpec = parseSpreads(nomadJobOpts)
     }
 
     JobVolume[] parseVolumes(Map nomadJobOpts){
@@ -177,4 +180,15 @@ class NomadJobOpts{
         }
     }
 
+    JobSpreads parseSpreads(Map nomadJobOpts){
+        if( nomadJobOpts.spreads && nomadJobOpts.spreads instanceof Closure){
+            def spec = new JobSpreads()
+            def closure = (nomadJobOpts.spreads as Closure)
+            def clone = closure.rehydrate(spec, closure.owner, closure.thisObject)
+            clone.resolveStrategy = Closure.DELEGATE_FIRST
+            clone()
+            spec.validate()
+            spec
+        }
+    }
 }

--- a/plugins/nf-nomad/src/main/nextflow/nomad/executor/TaskDirectives.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/executor/TaskDirectives.groovy
@@ -8,9 +8,12 @@ class TaskDirectives {
 
     public static final String SECRETS = "secret"
 
+    public static final String SPREAD = "spread"
+
     public static final List<String> ALL = [
             DATACENTERS,
             CONSTRAINTS,
-            SECRETS
+            SECRETS,
+            SPREAD
     ]
 }

--- a/plugins/nf-nomad/src/main/nextflow/nomad/models/JobSpreads.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/models/JobSpreads.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023-, Stellenbosch University, South Africa
+ * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package nextflow.nomad.models
+
+import org.apache.commons.lang3.tuple.Pair
+import org.apache.commons.lang3.tuple.Triple
+
+/**
+ * Nomad Job Spread Spec
+ *
+ * @author Jorge Aguilera <jorge@edn.es>
+ */
+
+class JobSpreads {
+
+    private List<Triple<String, Integer, List<Pair<String, Integer>>>> raws= []
+
+    List<Triple<String, Integer, List<Pair<String, Integer>>>> getRaws() {
+        return raws
+    }
+
+    JobSpreads setSpread(Map map){
+        spread(map)
+    }
+
+    JobSpreads spread(Map map){
+        if( map.containsKey("name") && map.containsKey("weight")){
+            def name = map.name as String
+            def weight = map.weight as int
+            def targets = [] as List<Pair>
+            if( map.containsKey("targets") && map.targets instanceof Map){
+                (map.targets as Map).entrySet().each{entry->
+                    def target = entry.key as String
+                    if( entry.value.toString().isNumber() ){
+                        def targetW = entry.value as int
+                        targets.add( Pair.of(target, targetW))
+                    }
+                }
+            }
+            raws.add Triple.of(name, weight, targets)
+        }
+        this
+    }
+
+    void validate(){
+
+    }
+}

--- a/plugins/nf-nomad/src/main/nextflow/nomad/models/SpreadsBuilder.groovy
+++ b/plugins/nf-nomad/src/main/nextflow/nomad/models/SpreadsBuilder.groovy
@@ -1,0 +1,30 @@
+package nextflow.nomad.models
+
+import groovy.transform.CompileStatic
+import io.nomadproject.client.model.Spread
+import io.nomadproject.client.model.SpreadTarget
+
+/**
+ * Nomad Job Spread Spec Builder
+ *
+ * @author Jorge Aguilera <jorge@edn.es>
+ */
+
+@CompileStatic
+class SpreadsBuilder {
+
+    static List<Spread> spreadsSpecToList(JobSpreads spreads){
+        def ret = [] as List<Spread>
+
+        spreads.raws.each{raw->
+            def targets = [] as List<SpreadTarget>
+            raw.right.each {
+                targets.add( new SpreadTarget(value: it.left, percent: it.right) )
+            }
+            ret.add new Spread(attribute: raw.left, weight: raw.middle, spreadTarget: targets)
+        }
+
+        return ret
+    }
+
+}

--- a/plugins/nf-nomad/src/test/nextflow/nomad/config/NomadConfigSpec.groovy
+++ b/plugins/nf-nomad/src/test/nextflow/nomad/config/NomadConfigSpec.groovy
@@ -295,4 +295,36 @@ class NomadConfigSpec extends Specification {
         then:
         thrown(IllegalArgumentException)
     }
+
+    void "should instantiate a spread spec if specified"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [spreads : {
+                    spread = [name:'test', weight:100]
+                }]
+        ])
+
+        then:
+        config.jobOpts.spreadsSpec
+        config.jobOpts.spreadsSpec.getRaws().size() == 1
+        config.jobOpts.spreadsSpec.getRaws().first().left == 'test'
+        config.jobOpts.spreadsSpec.getRaws().first().middle == 100
+        config.jobOpts.spreadsSpec.getRaws().first().right.size() == 0
+
+        when:
+        def config2 = new NomadConfig([
+                jobs: [spreads : {
+                    spread = [name:'test', weight:100, targets:[ a:50, b:100]]
+                }]
+        ])
+
+        then:
+        config2.jobOpts.spreadsSpec
+        config2.jobOpts.spreadsSpec.getRaws().size() == 1
+        config2.jobOpts.spreadsSpec.getRaws().first().left == 'test'
+        config2.jobOpts.spreadsSpec.getRaws().first().middle == 100
+        config2.jobOpts.spreadsSpec.getRaws().first().right.size() == 2
+        config2.jobOpts.spreadsSpec.getRaws().first().right.first().left == 'a'
+        config2.jobOpts.spreadsSpec.getRaws().first().right.first().right == 50
+    }
 }

--- a/validation/spread/main.nf
+++ b/validation/spread/main.nf
@@ -1,0 +1,18 @@
+#!/usr/bin/env nextflow
+
+process sayHello {
+    container   'ubuntu:20.04'
+
+    input:
+    val x
+    output:
+    stdout
+    script:
+    """
+    echo '$x world!'
+    """
+}
+
+workflow {
+    Channel.of('Bonjour', 'Ciao', 'Hello', 'Hola') | sayHello | view
+}

--- a/validation/spread/node-nextflow.config
+++ b/validation/spread/node-nextflow.config
@@ -1,0 +1,35 @@
+plugins {
+    id "nf-nomad@${System.getenv("NOMAD_PLUGIN_VERSION") ?: "latest"}"
+}
+
+process {
+    executor = "nomad"
+}
+
+nomad {
+
+    client {
+        address = "http://localhost:4646"
+    }
+
+    jobs {
+        deleteOnCompletion = false
+        volume = { type "host" name "scratchdir" }
+
+        spreads = {
+            spread = [ name:'node.datacenter', weight: 50 ]
+        }
+    }
+
+}
+
+profiles{
+    localnomad{
+        process {
+            withName: sayHello {
+                datacenters = ['test-datacenter', 'demo-datacenter']
+                spread = [ name:'node.datacenter', weight: 50, targets : ['us-east1':70, 'us-east2':30] ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
this is a WIP implementation for `spread` using a "map" syntax, i.e.

```
jobs {
        spreads = {
            spread = name:'node.datacenter', weight: 50, targets: ['a': 20]
        }
    }
```

Attached you can see how the spread is sent to cluster in the Job defintion

![imagen](https://github.com/user-attachments/assets/c08020c7-f2d8-457e-a9e3-9884ce0458e1)
