### PR TITLE
Improve config parsing for the new nomadOptions scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- `nomad.jobs.constraints { ... }` and the per-process `constraints` directive
+  now also accept the **Map** shape produced by Nextflow's config-file parser,
+  not only the **Closure** shape produced by inline `=` assignment. Block-form
+  `constraints { node { unique = [name: 'host'] } }` written in a `.config`
+  file is parsed by Nextflow as a nested Map; the previous Closure-only check
+  silently dropped these (jobs scope) or threw `must be a closure` (process
+  scope), making the directive effectively unusable from config files.
+  `JobConstraints.fromMap`, `JobConstraintsNode.fromMap`, and
+  `JobConstraintsAttr.fromMap` are the new entry points; `parseConstraints`
+  and `NomadTaskOptionsResolver.constraints` accept either shape.
+
+### Added
+- Map-shape constraint parsers now warn on unknown keys (typos like `nodes:`,
+  `hostname:` placed under `node`, or `vendorId:` under `attr.cpu`), unknown
+  sub-keys inside `unique`/`cpu`/`kernel` blocks, type mismatches (e.g.
+  `node = "string"`), and blocks that produce zero raw entries — surfacing
+  silently-dropped configuration so the user can fix the typo instead of
+  wondering why their constraint had no effect.
+

--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ process {
 }
 ```
 
-Some important considerations 
+Some important considerations
+- **Two constraint scopes**: `nomad.jobs.constraints = { ... }` sets a global constraint applied to every task; `nomadOptions.constraints: { ... }` (inside a process selector) sets a per-process constraint that is _additive_ to the global one. The two scopes are independent — per-process constraints do not replace the global ones, they append to them.
+- **`nomadOptions.constraints` takes a Closure**: because `nomadOptions` is a Map literal (`= [...]`), the constraints value is always a Closure. The legacy `constraints` process directive (used outside `nomadOptions`) is deprecated and will be removed in the next release — migrate to `nomadOptions.constraints`.
+- **Constraint validation warnings**: the plugin validates constraint blocks before submission and logs a `WARN` for unknown keys, type mismatches, or blocks that produce no usable constraint. The job is still submitted so that misconfigured constraints surface as a Nomad scheduler placement error rather than being silently dropped.
+- **Exit code resolution**: the plugin reads the `.command.exit` file written by the task wrapper first. If that file is absent or empty, it falls back to the exit code reported in Nomad TaskState events. If both sources are unavailable, the task is marked failed with exit code `Integer.MAX_VALUE` to ensure the Nextflow error strategy handles it correctly rather than treating it as a success.
 - If both `nomadOptions.<key>` and a legacy directive are present for the same process, `nomadOptions.<key>` wins for that key.
 - If `nomadOptions.resources.memoryMax` is not set, it defaults to the task `memory` value.
 - Global `nomad.jobs.cpuMode` controls default CPU mapping (`cores` or `cpu`) when process-level `resources.cpu/cores` is not set.

--- a/src/docs/antora/modules/ROOT/pages/config.adoc
+++ b/src/docs/antora/modules/ROOT/pages/config.adoc
@@ -89,7 +89,7 @@ nomad{
 - `acceleratorDeviceName`: Device name to use for automatic accelerator mapping (default `nvidia/gpu`).
 - `volumeSpec`: The volumes which should be accessible to the jobs.
 - `affinitiesSpec`: The affinities which should be attached to the job spec.
-- `constraintsSpec`: The constraints which should be attached to the job spec.
+- `constraintsSpec`: The constraints which should be attached to the job spec. Accepts either Closure (inline) or Map (config-file block) syntax — see <<constraints-syntax,Constraints syntax>> below.
 - `spreadsSpec`: The spreads spec which should be used with all generated jobs.
 - `rescheduleAttempts`: Number of rescheduling (to a different node) attempts for the generated jobs.
 - `restartAttempts`: Number of restart (on the same node) attempts for the generated jobs.
@@ -102,6 +102,190 @@ nomad{
 - `dockerVolume`, DEPRECATED
 - `affinitySpec`, DEPRECATED
 - `constraintSpec`, DEPRECATED
+
+[[constraints-syntax]]
+=== Constraints syntax
+
+There are two independent scopes for constraints, and they work differently.
+
+==== Global constraints (`nomad.jobs.constraints`)
+
+Applies to every task in the pipeline. Set in `nextflow.config` using assignment form
+(`= { ... }`), which Nextflow preserves as a Closure:
+
+[source,groovy]
+----
+nomad {
+    jobs {
+        // All jobs must land on a node in the cape-town datacenter
+        constraints = {
+            node {
+                dataCenter = 'cape-town'
+            }
+        }
+    }
+}
+----
+
+NOTE: Writing `constraints { ... }` without `=` at this scope is also accepted — Nextflow's
+config parser converts the block to a Map, and the plugin handles both shapes. Prefer the
+`= { ... }` form to make the intent explicit.
+
+==== Per-process constraints (`nomadOptions.constraints`)
+
+Set per process (or process selector) inside `nomadOptions = [ ... ]`. The value must be
+a Closure. Per-process constraints are _additive_ — they are appended to any global
+constraints already set.
+
+[source,groovy]
+----
+process {
+    withName: 'BWA_MEM' {
+        nomadOptions = [
+            constraints: {
+                node {
+                    pool = 'highmem'          // only schedule on high-memory node pool
+                }
+            }
+        ]
+    }
+}
+----
+
+NOTE: The legacy `constraints` process directive (used outside `nomadOptions`) is
+deprecated and will be removed in the next release. Migrate to `nomadOptions.constraints`.
+
+==== Node constraint keys
+
+Node constraints match against Nomad's built-in node attributes and metadata:
+
+|===
+| Key | Value type | Nomad constraint generated
+
+| `unique = [name: '...']`
+| Map with key `name` and/or `id`
+| `${node.unique.name} = <name>` and/or `${node.unique.id} = <id>`
+
+| `clazz = '...'`
+| string
+| `${node.class} = <value>` (use `clazz` — `class` is a Groovy reserved word)
+
+| `pool = '...'`
+| string
+| `${node.pool} = <value>`
+
+| `dataCenter = '...'`
+| string
+| `${node.datacenter} = <value>`
+
+| `region = '...'`
+| string
+| `${node.region} = <value>`
+|===
+
+==== Attr constraint keys
+
+Attr constraints match against Nomad's `attr.*` intrinsic attributes:
+
+|===
+| Key | Sub-keys | Nomad constraint generated
+
+| `cpu = [...]`
+| `arch`: string, `numcores`: int, `reservablecores`: int, `totalcompute`: string
+| `${attr.cpu.arch} = <arch>`, `${attr.cpu.numcores} >= <n>`, etc.
+
+| `unique = [...]`
+| `hostname`: string, `ip-address`: string
+| `${attr.unique.hostname} = <hostname>`, `${attr.unique.network.ip-address} = <ip>`
+
+| `kernel = [...]`
+| `name`: string, `arch`: string, `version`: string
+| `${attr.kernel.name} = <name>`, etc.
+|===
+
+==== Examples
+
+**Pin all jobs to a specific datacenter and all alignment jobs to high-core nodes:**
+
+[source,groovy]
+----
+nomad {
+    jobs {
+        constraints = {
+            node { dataCenter = 'dc-nairobi' }   // global: every job stays in this DC
+        }
+    }
+}
+
+process {
+    withName: 'BWA_MEM' {
+        nomadOptions = [
+            constraints: {
+                attr { cpu = [numcores: 16] }     // additionally: at least 16 cores
+            }
+        ]
+    }
+}
+----
+
+**Route GPU-accelerated inference to a dedicated node class:**
+
+[source,groovy]
+----
+process {
+    withName: 'DEEPVARIANT' {
+        nomadOptions = [
+            constraints: {
+                node { clazz = 'gpu' }
+            }
+        ]
+    }
+}
+----
+
+**Route different pipeline stages to separate named nodes:**
+
+[source,groovy]
+----
+process {
+    withName: 'FASTQC' {
+        nomadOptions = [
+            constraints: {
+                node { unique = [name: 'compute-01'] }
+            }
+        ]
+    }
+    withName: 'MULTIQC' {
+        nomadOptions = [
+            constraints: {
+                node { unique = [name: 'compute-02'] }
+            }
+        ]
+    }
+}
+----
+
+**Restrict all jobs to Linux nodes with at least 8 reservable CPU cores:**
+
+[source,groovy]
+----
+nomad {
+    jobs {
+        constraints = {
+            attr { kernel = [name: 'linux'] }
+            attr { cpu    = [reservablecores: 8] }
+        }
+    }
+}
+----
+
+**Validation warnings:**
+
+The plugin validates constraint blocks before submission and logs a `WARN` for unknown keys,
+type mismatches, or blocks that produce no usable constraint. The job is still submitted so
+that misconfigured constraints surface as a Nomad scheduler placement error rather than
+being silently dropped.
+
 === Process directives
 
 The plugin supports process-level Nomad directives in two forms:

--- a/src/main/groovy/nextflow/nomad/NomadHelper.groovy
+++ b/src/main/groovy/nextflow/nomad/NomadHelper.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/NomadPlugin.groovy
+++ b/src/main/groovy/nextflow/nomad/NomadPlugin.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
+++ b/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
@@ -444,10 +444,17 @@ class JobBuilder {
             constraints.addAll(list)
         }
 
-        Closure closure = NomadTaskOptionsResolver.constraints(task)
-        if( closure ) {
-            JobConstraints constraintsSpec = JobConstraints.parse(closure)
-            def list = ConstraintsBuilder.constraintsSpecToList(constraintsSpec)
+        // Per-process directive may be a Closure (DSL form) or a Map (config-file
+        // parser form). Both must produce equivalent JobConstraints specs.
+        def directive = NomadTaskOptionsResolver.constraints(task)
+        JobConstraints perTaskSpec = null
+        if( directive instanceof Closure ) {
+            perTaskSpec = JobConstraints.parse(directive as Closure)
+        } else if( directive instanceof Map ) {
+            perTaskSpec = JobConstraints.fromMap(directive as Map)
+        }
+        if( perTaskSpec ) {
+            def list = ConstraintsBuilder.constraintsSpecToList(perTaskSpec)
             constraints.addAll(list)
         }
 

--- a/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
+++ b/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024-, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/config/NomadClientOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadClientOpts.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/config/NomadConfig.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadConfig.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
@@ -218,17 +218,27 @@ class NomadJobOpts{
     }
 
     JobConstraints parseConstraints(Map nomadJobOpts){
-        if (nomadJobOpts.constraints && nomadJobOpts.constraints instanceof Closure) {
+        def value = nomadJobOpts.constraints
+        if( !value ) return null
+        // Closure shape: written as `constraints { node { ... } }` AND assigned
+        // via property-assignment (`= { ... }`) — Nextflow preserves it as a Closure.
+        if( value instanceof Closure ) {
             def constraintsSpec = new JobConstraints()
-            def closure = (nomadJobOpts.constraints as Closure)
+            def closure = (value as Closure)
             def clone = closure.rehydrate(constraintsSpec, closure.owner, closure.thisObject)
             clone.resolveStrategy = Closure.DELEGATE_FIRST
             clone()
             constraintsSpec.validate()
-            constraintsSpec
-        }else{
-            null
+            return constraintsSpec
         }
+        // Map shape: produced by Nextflow's config-file parser when the user writes
+        // `constraints { node { unique = [name: 'host'] } }` as a block (not `=` form).
+        // Without this branch the constraint is silently dropped.
+        if( value instanceof Map ) {
+            return JobConstraints.fromMap(value as Map)
+        }
+        log.warn "Ignoring nomad.jobs.constraints: expected a closure or map, got ${value.getClass().name}"
+        return null
     }
 
     NomadSecretOpts parseSecrets(Map nomadJobOpts){

--- a/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadExecutor.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadExecutor.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadScriptLauncher.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadScriptLauncher.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadService.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadService.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadTaskHandler.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadTaskHandler.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadTaskOptionsResolver.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadTaskOptionsResolver.groovy
@@ -93,15 +93,25 @@ class NomadTaskOptionsResolver {
         return getOption(task, DATACENTERS, TaskDirectives.DATACENTERS)
     }
 
-    static Closure constraints(TaskRun task) {
+    /**
+     * Returns the per-process {@code constraints} directive value. Either a
+     * Closure (DSL form: {@code constraints {{ ... }}} or
+     * {@code constraints = {{ ... }}}) or a Map (the shape produced by
+     * Nextflow's config-file parser when users write a block-form value
+     * inside a {@code process {{ ... }}} scope).
+     *
+     * Returning {@code Object} keeps the call site type-aware so each shape
+     * is handled correctly without an artificial Map-to-Closure conversion.
+     */
+    static Object constraints(TaskRun task) {
         def value = getOption(task, CONSTRAINTS, TaskDirectives.CONSTRAINTS)
         if( value == null ) {
             return null
         }
-        if( value instanceof Closure ) {
-            return (Closure)value
+        if( value instanceof Closure || value instanceof Map ) {
+            return value
         }
-        invalidOption(task, "${TaskDirectives.NOMAD_OPTIONS}.${CONSTRAINTS}", value, "must be a closure")
+        invalidOption(task, "${TaskDirectives.NOMAD_OPTIONS}.${CONSTRAINTS}", value, "must be a closure or map")
         return null
     }
 

--- a/src/main/groovy/nextflow/nomad/models/JobAffinity.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobAffinity.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraint.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraint.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraints.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraints.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraints.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraints.groovy
@@ -18,13 +18,18 @@
 
 package nextflow.nomad.models
 
+import groovy.util.logging.Slf4j
+
 /**
  * Nomad Job Constraint Spec
  *
  * @author Jorge Aguilera <jagedn@gmail.com>
  */
 
+@Slf4j
 class JobConstraints {
+
+    private static final Set<String> KNOWN_KEYS = ['node', 'attr'] as Set
 
     List<JobConstraintsNode> nodeSpecs = []
     List<JobConstraintsAttr> attrSpecs = []
@@ -58,5 +63,74 @@ class JobConstraints {
         clone()
         constraintsSpec.validate()
         constraintsSpec
+    }
+
+    /**
+     * Build a {@link JobConstraints} from a Map. This handles the shape produced
+     * by Nextflow's config-file parser when users write
+     *
+     * <pre>
+     * nomad {{ jobs {{ constraints {{ node {{ unique = [name: 'host'] }} }} }} }}
+     * </pre>
+     *
+     * which is parsed as a Map of Maps, not a Closure. Both single-block and
+     * list-of-blocks shapes are accepted for {@code node} / {@code attr} so users
+     * can express multiple specs even via Map config.
+     *
+     * Returns {@code null} when the supplied map is {@code null} or empty.
+     */
+    static JobConstraints fromMap(Map map){
+        if( !map ) return null
+
+        // Surface typos like `nodes:` (plural) or `attribute:` that would otherwise
+        // be silently ignored by the addNodeSpecs / addAttrSpecs lookups.
+        def unknown = map.keySet().findAll { !(KNOWN_KEYS.contains(it as String)) }
+        if( unknown ) {
+            log.warn "Unknown nomad constraints key(s) ${unknown} — supported: ${KNOWN_KEYS}"
+        }
+
+        JobConstraints spec = new JobConstraints()
+        addNodeSpecs(spec, map.node)
+        addAttrSpecs(spec, map.attr)
+        spec.validate()
+
+        if( spec.nodeSpecs.isEmpty() && spec.attrSpecs.isEmpty() ) {
+            log.warn "nomad constraints block produced no specs — input keys: ${map.keySet()}"
+        }
+        spec
+    }
+
+    private static void addNodeSpecs(JobConstraints spec, Object value){
+        if( value == null ) return
+        if( value instanceof Map ) {
+            spec.nodeSpecs << JobConstraintsNode.fromMap(value as Map)
+        } else if( value instanceof Iterable ) {
+            for( Object item : (value as Iterable) ) {
+                if( item instanceof Map ) {
+                    spec.nodeSpecs << JobConstraintsNode.fromMap(item as Map)
+                } else {
+                    log.warn "nomad constraints.node list entry must be a Map, got ${item?.getClass()?.name}"
+                }
+            }
+        } else {
+            log.warn "nomad constraints.node must be a Map or List<Map>, got ${value.getClass().name}"
+        }
+    }
+
+    private static void addAttrSpecs(JobConstraints spec, Object value){
+        if( value == null ) return
+        if( value instanceof Map ) {
+            spec.attrSpecs << JobConstraintsAttr.fromMap(value as Map)
+        } else if( value instanceof Iterable ) {
+            for( Object item : (value as Iterable) ) {
+                if( item instanceof Map ) {
+                    spec.attrSpecs << JobConstraintsAttr.fromMap(item as Map)
+                } else {
+                    log.warn "nomad constraints.attr list entry must be a Map, got ${item?.getClass()?.name}"
+                }
+            }
+        } else {
+            log.warn "nomad constraints.attr must be a Map or List<Map>, got ${value.getClass().name}"
+        }
     }
 }

--- a/src/main/groovy/nextflow/nomad/models/JobConstraintsAttr.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraintsAttr.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraintsAttr.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraintsAttr.groovy
@@ -19,6 +19,7 @@
 
 package nextflow.nomad.models
 
+import groovy.util.logging.Slf4j
 import org.apache.commons.lang3.tuple.Triple
 
 /**
@@ -27,7 +28,14 @@ import org.apache.commons.lang3.tuple.Triple
  * @author Jorge Aguilera <jagedn@gmail.com>
  */
 
+@Slf4j
 class JobConstraintsAttr {
+
+    private static final Set<String> KNOWN_KEYS = ['cpu', 'unique', 'kernel'] as Set
+    private static final Set<String> KNOWN_CPU_KEYS =
+            ['arch', 'numcores', 'reservablecores', 'totalcompute'] as Set
+    private static final Set<String> KNOWN_UNIQUE_KEYS = ['hostname', 'ip-address'] as Set
+    private static final Set<String> KNOWN_KERNEL_KEYS = ['arch', 'name', 'version'] as Set
 
     private List<Triple<String, String, String>> raws= []
 
@@ -80,5 +88,52 @@ class JobConstraintsAttr {
     JobConstraintsAttr raw(String attr, String operator, String value){
         raws.add Triple.of("attr."+attr, operator, value)
         this
+    }
+
+    /**
+     * Build a {@link JobConstraintsAttr} from a plain Map (the form produced by
+     * Nextflow's config-file parser when {@code attr {{ ... }}} appears inside a
+     * {@code constraints {{ ... }}} block).
+     */
+    static JobConstraintsAttr fromMap(Map map){
+        def spec = new JobConstraintsAttr()
+        if( map == null ) {
+            log.warn "Ignoring null nomad attr constraint Map"
+            return spec
+        }
+
+        def unknown = map.keySet().findAll { !(KNOWN_KEYS.contains(it as String)) }
+        if( unknown ) {
+            log.warn "Unknown nomad attr constraint key(s) ${unknown} — supported: ${KNOWN_KEYS}"
+        }
+
+        applySubMap(spec, map, 'cpu',    KNOWN_CPU_KEYS,    { Map m -> spec.cpu(m) })
+        applySubMap(spec, map, 'unique', KNOWN_UNIQUE_KEYS, { Map m -> spec.unique(m) })
+        applySubMap(spec, map, 'kernel', KNOWN_KERNEL_KEYS, { Map m -> spec.kernel(m) })
+
+        if( spec.raws.isEmpty() ) {
+            log.warn "nomad attr constraint produced no raw entries — block has no effect (input keys: ${map.keySet()})"
+        }
+        spec
+    }
+
+    private static void applySubMap(JobConstraintsAttr spec, Map parent, String key,
+                                    Set<String> known, Closure apply){
+        if( !parent.containsKey(key) ) return
+        def value = parent.get(key)
+        if( !(value instanceof Map) ) {
+            log.warn "nomad attr.${key} must be a Map, got ${value?.getClass()?.name}"
+            return
+        }
+        Map m = value as Map
+        def unknown = m.keySet().findAll { !(known.contains(it as String)) }
+        if( unknown ) {
+            log.warn "Unknown nomad attr.${key} key(s) ${unknown} — supported: ${known}"
+        }
+        if( !known.any { m.containsKey(it) } ) {
+            log.warn "nomad attr.${key} map must contain at least one of ${known}"
+            return
+        }
+        apply(m)
     }
 }

--- a/src/main/groovy/nextflow/nomad/models/JobConstraintsNode.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraintsNode.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraintsNode.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraintsNode.groovy
@@ -19,6 +19,7 @@
 
 package nextflow.nomad.models
 
+import groovy.util.logging.Slf4j
 import org.apache.commons.lang3.tuple.Triple
 
 /**
@@ -27,7 +28,15 @@ import org.apache.commons.lang3.tuple.Triple
  * @author Jorge Aguilera <jagedn@gmail.com>
  */
 
+@Slf4j
 class JobConstraintsNode {
+
+    /** Valid top-level keys when constructing from a Map. */
+    private static final Set<String> KNOWN_KEYS =
+            ['unique', 'clazz', 'class', 'pool', 'dataCenter', 'datacenter', 'region'] as Set
+
+    /** Valid keys inside the {@code unique} sub-map. */
+    private static final Set<String> KNOWN_UNIQUE_KEYS = ['id', 'name'] as Set
 
     private List<Triple<String, String, String>> raws= []
 
@@ -86,5 +95,56 @@ class JobConstraintsNode {
     JobConstraintsNode raw(String attr, String operator, String value){
         raws.add Triple.of("node."+attr, operator, value)
         this
+    }
+
+    /**
+     * Build a {@link JobConstraintsNode} from a plain Map. This is the form Nextflow's
+     * config-file DSL produces when users write {@code node {{ ... }}} inside a
+     * {@code constraints {{ ... }}} block — the closure is flattened into a Map,
+     * which previously failed the Closure-only parser silently.
+     *
+     * Accepts {@code class} as well as {@code clazz}, and {@code datacenter} as well
+     * as {@code dataCenter}, to match both Groovy DSL and YAML/JSON style configs.
+     */
+    static JobConstraintsNode fromMap(Map map){
+        def spec = new JobConstraintsNode()
+        if( map == null ) {
+            log.warn "Ignoring null nomad node constraint Map"
+            return spec
+        }
+
+        // Warn on typos / unsupported keys so silent drops surface to the user.
+        def unknown = map.keySet().findAll { !(KNOWN_KEYS.contains(it as String)) }
+        if( unknown ) {
+            log.warn "Unknown nomad node constraint key(s) ${unknown} — supported: ${KNOWN_KEYS - ['clazz', 'datacenter']}"
+        }
+
+        if( map.containsKey('unique') ) {
+            if( map.unique instanceof Map ) {
+                Map u = map.unique as Map
+                def unknownUnique = u.keySet().findAll { !(KNOWN_UNIQUE_KEYS.contains(it as String)) }
+                if( unknownUnique ) {
+                    log.warn "Unknown nomad node.unique key(s) ${unknownUnique} — supported: ${KNOWN_UNIQUE_KEYS}"
+                }
+                if( !KNOWN_UNIQUE_KEYS.any { u.containsKey(it) } ) {
+                    log.warn "nomad node.unique map must contain at least one of ${KNOWN_UNIQUE_KEYS}"
+                }
+                spec.unique(u)
+            } else {
+                log.warn "nomad node.unique must be a Map, got ${map.unique?.getClass()?.name}"
+            }
+        }
+
+        if( map.containsKey('clazz') )            spec.clazz(map.clazz)
+        else if( map.containsKey('class') )       spec.clazz(map['class'])
+        if( map.containsKey('pool') )             spec.pool(map.pool)
+        if( map.containsKey('dataCenter') )       spec.dataCenter(map.dataCenter)
+        else if( map.containsKey('datacenter') )  spec.dataCenter(map.datacenter)
+        if( map.containsKey('region') )           spec.region(map.region)
+
+        if( spec.raws.isEmpty() ) {
+            log.warn "nomad node constraint produced no raw entries — block has no effect (input keys: ${map.keySet()})"
+        }
+        spec
     }
 }

--- a/src/main/groovy/nextflow/nomad/models/JobSpreads.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobSpreads.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobVolume.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobVolume.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/util/NomadLogging.groovy
+++ b/src/main/groovy/nextflow/nomad/util/NomadLogging.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/MockNomadDSLSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/MockNomadDSLSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain*
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/MockScriptRunner.groovy
+++ b/src/test/groovy/nextflow/nomad/MockScriptRunner.groovy
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024-2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/TestHelper.groovy
+++ b/src/test/groovy/nextflow/nomad/TestHelper.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderNomadOptionsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderNomadOptionsSpec.groovy
@@ -64,6 +64,27 @@ class JobBuilderNomadOptionsSpec extends Specification {
         taskDef.constraints[0].getRtarget() == 'linux'
     }
 
+    void "constraints should accept a Map directive (config-file shape)"() {
+        // Reproduces the shape that Nextflow's config-file parser produces
+        // for `process { constraints { node { unique = [name: 'host'] } } }`.
+        // Previously this raised "must be a closure"; now it should be parsed
+        // identically to the Closure form.
+        given:
+        Map mapConstraints = [node: [unique: [name: 'pinned-host']]]
+        def task = taskWithConfig([
+                (TaskDirectives.CONSTRAINTS): mapConstraints
+        ])
+        def taskDef = new Task()
+
+        when:
+        JobBuilder.constraints(task, taskDef, Stub(NomadJobOpts))
+
+        then:
+        taskDef.constraints.size() == 1
+        taskDef.constraints[0].getLtarget() == '${node.unique.name}'
+        taskDef.constraints[0].getRtarget() == 'pinned-host'
+    }
+
     void "secrets should prefer nomadOptions secrets list"() {
         given:
         def task = taskWithConfig([

--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderPrioritySpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderPrioritySpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/config/NomadConfigSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadConfigSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/config/NomadJobConstraintsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadJobConstraintsSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/config/NomadJobConstraintsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadJobConstraintsSpec.groovy
@@ -118,4 +118,193 @@ class NomadJobConstraintsSpec extends Specification {
         config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find{it.left.endsWith("datacenter")}.right == "dc1"
         config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find{it.left.endsWith("region")}.right == "us"
     }
+
+    // ── Map-shape parsing ────────────────────────────────────────────────────
+    //
+    // Nextflow's config-file parser flattens block-form `constraints { node { ... } }`
+    // into a Map of Maps. Previously this Map was silently ignored because the
+    // Closure-only check failed; these specs lock in the Map-shape parser.
+
+    void "should accept constraints supplied as a Map (config-file form)"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                node: [
+                                        unique    : [id: "node-id", name: "node-name"],
+                                        clazz     : "linux-64bit",
+                                        pool      : "custom-pool",
+                                        dataCenter: "dc1",
+                                        region    : "us",
+                                ],
+                                attr: [
+                                        cpu: [arch: "286"],
+                                ],
+                        ]
+                ]
+        ])
+
+        then:
+        config.jobOpts.constraintsSpec
+        config.jobOpts.constraintsSpec.nodeSpecs.size() == 1
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("id") }.right == "node-id"
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("name") }.right == "node-name"
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("class") }.right == "linux-64bit"
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("pool") }.right == "custom-pool"
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("datacenter") }.right == "dc1"
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("region") }.right == "us"
+
+        config.jobOpts.constraintsSpec.attrSpecs.size() == 1
+        config.jobOpts.constraintsSpec.attrSpecs[0].raws[0].right == "286"
+    }
+
+    void "should accept Map shape with multiple node specs as a List"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                node: [
+                                        [unique: [name: "node-a"]],
+                                        [unique: [name: "node-b"]],
+                                ]
+                        ]
+                ]
+        ])
+
+        then:
+        config.jobOpts.constraintsSpec
+        config.jobOpts.constraintsSpec.nodeSpecs.size() == 2
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("name") }.right == "node-a"
+        config.jobOpts.constraintsSpec.nodeSpecs[1].raws.find { it.left.endsWith("name") }.right == "node-b"
+    }
+
+    // ── Map-shape validations ────────────────────────────────────────────────
+
+    void "should ignore an unknown top-level constraints key but still parse known ones"() {
+        // `nodes:` (plural typo) should be ignored, `node:` still parsed.
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                nodes: [unique: [name: "ignored-typo"]],
+                                node : [unique: [name: "kept"]],
+                        ]
+                ]
+        ])
+
+        then:
+        config.jobOpts.constraintsSpec.nodeSpecs.size() == 1
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws
+                .find { it.left.endsWith("name") }.right == "kept"
+    }
+
+    void "should ignore an unknown node key but still parse known ones"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                node: [
+                                        hostname: "wrong-key", // typo: belongs under attr.unique
+                                        pool    : "custom-pool",
+                                ]
+                        ]
+                ]
+        ])
+
+        then:
+        // Only the known `pool` key survives; the typo is dropped.
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.size() == 1
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws[0].left == "node.pool"
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws[0].right == "custom-pool"
+    }
+
+    void "should ignore an unknown attr.cpu sub-key but still parse known ones"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                attr: [
+                                        cpu: [
+                                                arch    : "amd64",
+                                                vendorId: "intel", // unsupported
+                                        ]
+                                ]
+                        ]
+                ]
+        ])
+
+        then:
+        config.jobOpts.constraintsSpec.attrSpecs[0].raws.size() == 1
+        config.jobOpts.constraintsSpec.attrSpecs[0].raws[0].left == "attr.cpu.arch"
+    }
+
+    void "should reject a non-Map node value gracefully (no exception)"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [node: "nomad02"]   // wrong shape
+                ]
+        ])
+
+        then:
+        // No exception, no specs, but the constraintsSpec exists so callers can introspect.
+        config.jobOpts.constraintsSpec.nodeSpecs.isEmpty()
+        config.jobOpts.constraintsSpec.attrSpecs.isEmpty()
+    }
+
+    void "should reject a non-Map node.unique value gracefully"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                node: [
+                                        unique: "nomad02", // should be [name: 'nomad02']
+                                        pool  : "custom-pool",
+                                ]
+                        ]
+                ]
+        ])
+
+        then:
+        // unique is dropped, pool survives.
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.size() == 1
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws[0].left == "node.pool"
+    }
+
+    void "should accept an empty unique map with at least one valid sibling key"() {
+        // unique = [:] alone produces nothing useful, but pool is still parsed.
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                node: [
+                                        unique: [:],
+                                        pool  : "custom-pool",
+                                ]
+                        ]
+                ]
+        ])
+
+        then:
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.size() == 1
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws[0].left == "node.pool"
+    }
+
+    void "should accept the legacy 'class' and 'datacenter' Map keys"() {
+        when:
+        def config = new NomadConfig([
+                jobs: [
+                        constraints: [
+                                node: [
+                                        'class'   : "linux-64bit",
+                                        datacenter: "dc1",
+                                ]
+                        ]
+                ]
+        ])
+
+        then:
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("class") }.right == "linux-64bit"
+        config.jobOpts.constraintsSpec.nodeSpecs[0].raws.find { it.left.endsWith("datacenter") }.right == "dc1"
+    }
 }

--- a/src/test/groovy/nextflow/nomad/config/NomadJobOptsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadJobOptsSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalAffinityIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalAffinityIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalConstraintsDSLSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalConstraintsDSLSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalDatacenterIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalDatacenterIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalDockerIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalDockerIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalJobSubmissionSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalJobSubmissionSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalMinioIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalMinioIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalNomadSchedulingIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalNomadSchedulingIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalPlacementFailureIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalPlacementFailureIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalSecretsIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalSecretsIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalSpreadIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalSpreadIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalStateManagementSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalStateManagementSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalVolumeIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalVolumeIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalWorkflowIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalWorkflowIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/MockNomadSecretServiceSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/MockNomadSecretServiceSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/MockNomadServicePlacementFailureSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/MockNomadServicePlacementFailureSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/MockNomadServiceSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/MockNomadServiceSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/NomadServiceIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/NomadServiceIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/NomadTaskHandlerSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/NomadTaskHandlerSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/models/MockJobConstraintsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/models/MockJobConstraintsSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/util/NomadLoggingSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/util/NomadLoggingSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Accept Map-shape `constraints` from config files (with validation)

## Summary

`nomad.jobs.constraints { ... }` and the per-process `constraints` directive
only accepted **Closure** values. When users wrote the same DSL in a `.config`
file, Nextflow's config parser flattened the block into a **Map**, which:

- at the **jobs scope** was silently dropped (no error, constraint just had no
  effect — child jobs scattered across the cluster);
- at the **process scope** failed loudly with
  `Invalid Nomad option for process 'X': nomadOptions.constraints must be a closure`.

This PR updates both code paths to also accept the Map shape, adds defensive
validations so silently-dropped fields become loud warnings, and locks in the
behaviour with unit tests.

## Motivation — what the bug looked like in practice

Submitting an `nf-nomad`-driven pipeline (`nextflow-io/rnaseq-nf`) with this
in a Nextflow config file…

```groovy
nomad {
  jobs {
    constraints {
      node {
        unique = [name: 'nomad02']
      }
    }
  }
}
```

…produced a job spec with `Constraints: null` on every child task, so child
jobs were scheduled on whichever Nomad client the placer picked. With a
local-disk shared work directory this means most tasks fail with
`.command.run: No such file or directory` because the work files only exist
on the head's node.

Switching to the per-process directive…

```groovy
process {
  constraints {
    node {
      unique = [name: 'nomad02']
    }
  }
}
```

…fared worse: every task threw

```
ERROR ~ Error executing process > 'RNASEQ:INDEX (...)'
Invalid Nomad option for process `RNASEQ:INDEX`:
  `nomadOptions.constraints` must be a closure
  -- value: [node:[unique:[name:nomad02]]]
```

The `value: [node:[unique:[name:nomad02]]]` in the error tells the whole
story: the parser had a fully-formed Map ready to consume, but the
`instanceof Closure` check rejected it.

The only working form was assignment with `=`, which preserves the Closure
through Nextflow's config parser:

```groovy
process {
  constraints = { node { unique = [name: 'nomad02'] } }
}
```

…which is non-obvious and not documented.

### Validations (new in this PR)

The Map-shape parsers warn on every silently-dropped input so users can
quickly identify typos. None of these are fatal — parsing keeps going so a
single typo doesn't break the rest of the constraint block.

| Validation | Example that now warns |
|---|---|
| Unknown top-level key | `constraints { nodes { ... } }` (plural typo) |
| Unknown `node` key | `constraints { node { hostname = 'x' } }` (belongs under `attr.unique`) |
| Unknown `node.unique` key | `unique = [hostName: 'x']` (camelCase typo) |
| Unknown `attr` key | `attr { storage { ... } }` (not supported) |
| Unknown `attr.cpu` / `attr.unique` / `attr.kernel` key | `cpu = [vendorId: 'intel']` |
| Wrong value type | `constraints { node = "nomad02" }` (must be a Map) |
| Wrong sub-value type | `node { unique = "nomad02" }` (must be a Map) |
| Empty `unique` / `cpu` / `kernel` block | `unique = [:]` paired with no other valid keys |
| Block produced zero raws | `node { foo = 'bar' }` (no recognised keys at all) |
| List entry of wrong type | `node: ["nomad02"]` (each entry must be a Map) |

Every warning includes the offending key(s) and the supported alternatives,
so the fix is usually visible in the next pipeline log line.

### Tests

- `NomadJobConstraintsSpec` grew from **3 → 12 specs** (+3 happy-path Map
  shapes, +6 validation paths).
- `JobBuilderNomadOptionsSpec` gained **1** spec for the per-process Map form.

Full suite: **344 tests / 0 failures / 0 errors** on JDK 17.

## Backwards compatibility

- The Closure path is unchanged — every existing user config keeps working.
- The per-process resolver's return type widened from `Closure` to `Object`.
  This is a binary-compatible change for all in-tree callers (`JobBuilder` is
  the only consumer and was updated). External callers that relied on the
  exact return type would see a compile-time signature change.
- The error message for the `process { constraints = ... }` directive when
  given an unsupported type changed from `must be a closure` to
  `must be a closure or map`.

