### PR TITLE
Update project licensing header

### DIFF
--- a/src/main/groovy/nextflow/nomad/NomadHelper.groovy
+++ b/src/main/groovy/nextflow/nomad/NomadHelper.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/NomadPlugin.groovy
+++ b/src/main/groovy/nextflow/nomad/NomadPlugin.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
+++ b/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024-, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/config/NomadClientOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadClientOpts.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/config/NomadConfig.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadConfig.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadExecutor.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadExecutor.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadScriptLauncher.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadScriptLauncher.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadService.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadService.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/executor/NomadTaskHandler.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadTaskHandler.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobAffinity.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobAffinity.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraint.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraint.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraints.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraints.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraintsAttr.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraintsAttr.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobConstraintsNode.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobConstraintsNode.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobSpreads.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobSpreads.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/models/JobVolume.groovy
+++ b/src/main/groovy/nextflow/nomad/models/JobVolume.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/nomad/util/NomadLogging.groovy
+++ b/src/main/groovy/nextflow/nomad/util/NomadLogging.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/MockNomadDSLSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/MockNomadDSLSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain*
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/MockScriptRunner.groovy
+++ b/src/test/groovy/nextflow/nomad/MockScriptRunner.groovy
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024-2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/TestHelper.groovy
+++ b/src/test/groovy/nextflow/nomad/TestHelper.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderPrioritySpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderPrioritySpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/config/NomadConfigSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadConfigSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/config/NomadJobConstraintsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadJobConstraintsSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/config/NomadJobOptsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadJobOptsSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalAffinityIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalAffinityIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalConstraintsDSLSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalConstraintsDSLSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalDatacenterIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalDatacenterIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalDockerIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalDockerIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalJobSubmissionSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalJobSubmissionSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalMinioIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalMinioIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalNomadSchedulingIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalNomadSchedulingIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalPlacementFailureIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalPlacementFailureIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalSecretsIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalSecretsIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalSpreadIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalSpreadIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalStateManagementSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalStateManagementSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalVolumeIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalVolumeIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/LocalWorkflowIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/LocalWorkflowIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/MockNomadSecretServiceSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/MockNomadSecretServiceSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/MockNomadServicePlacementFailureSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/MockNomadServicePlacementFailureSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/MockNomadServiceSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/MockNomadServiceSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/NomadServiceIntegrationSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/NomadServiceIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/executor/NomadTaskHandlerSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/NomadTaskHandlerSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/models/MockJobConstraintsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/models/MockJobConstraintsSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/nomad/util/NomadLoggingSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/util/NomadLoggingSpec.groovy
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023-, Stellenbosch University, South Africa
  * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
+ * Copyright 2026-, Incremental Steps Software Solutions OÜ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION

Adds a third copyright line to every Groovy source file under src/main and src/test:

    * Copyright 2023-, Stellenbosch University, South Africa
    * Copyright 2024, Evaluacion y Desarrollo de Negocios, Spain
    * Copyright 2026-, Incremental Steps Software Solutions OÜ

License terms (Apache 2.0) and COPYING file unchanged. 46 pre-existing source files touched, header-only edits, all tests still passing.