### PR TITLE
add networkMode

### DIFF
--- a/src/docs/antora/modules/ROOT/pages/config.adoc
+++ b/src/docs/antora/modules/ROOT/pages/config.adoc
@@ -28,6 +28,7 @@ nomad{
         deleteOnCompletion = false
         cleanup = 'onSuccess'             // always | never | onSuccess
         privileged = true
+        networkMode = 'test'                // optional. Can be bridge, host or a named network
         cpuMode = 'cores'                 // or 'cpu'
         acceleratorAutoDevice = true      // map Nextflow accelerator directive to Nomad resources.device
         acceleratorDeviceName = 'nvidia/gpu'
@@ -84,6 +85,7 @@ nomad{
 - `region`: The region for job submission.
 - `namespace`: The namespace to be used for all Nextflow jobs.
 - `privileged`: Run Docker tasks in privileged mode (default `true`).
+- 'networkMode' Mode of the network. This option is only supported on Linux clients. The following modes are available: none, bridge (default), host, <cni_network_name>
 - `cpuMode`: How task `cpus` maps to Nomad resources when process-level overrides are not set. Use `cores` (default) or `cpu`.
 - `acceleratorAutoDevice`: When `true` (default), map Nextflow `accelerator` requests to Nomad `resources.device` automatically.
 - `acceleratorDeviceName`: Device name to use for automatic accelerator mapping (default `nvidia/gpu`).

--- a/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
+++ b/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
@@ -263,6 +263,7 @@ class JobBuilder {
                         work_dir  : workingDir,
                         command   : args.first(),
                         args      : args.tail(),
+                        network_mode: jobOpts.networkMode ?: 'bridge'
                 ] as Map<String, Object>,
                 env: env,
         )

--- a/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
@@ -63,6 +63,7 @@ class NomadJobOpts{
     Integer rescheduleAttempts
     Integer restartAttempts
     Boolean privileged
+    String networkMode
     String cpuMode
     Boolean acceleratorAutoDevice
     String acceleratorDeviceName
@@ -111,6 +112,7 @@ class NomadJobOpts{
         privileged = nomadJobOpts.containsKey("privileged")
                 ? Boolean.valueOf(nomadJobOpts.privileged.toString())
                 : true
+        networkMode = nomadJobOpts.containsKey("networkMode") ?: "bridge"
         cpuMode = parseCpuMode(nomadJobOpts.get('cpuMode') ?: sysEnv.get('NF_NOMAD_CPU_MODE'))
         acceleratorAutoDevice = nomadJobOpts.containsKey('acceleratorAutoDevice')
                 ? Boolean.valueOf(nomadJobOpts.get('acceleratorAutoDevice')?.toString())

--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderSpec.groovy
@@ -99,4 +99,23 @@ class JobBuilderSpec extends Specification {
     }
 
 
+    def "test networkMode config"() {
+        given:
+        def jobOpts = Mock(NomadJobOpts){
+            getNetworkMode() >> 'test'
+        }
+        def taskRun = Mock(TaskRun)
+        def args = ["arg1", "arg2"]
+        def env = ["key": "value"]
+
+        taskRun.container >> "test-container"
+        taskRun.workDir >> new File("/test/workdir").toPath()
+        taskRun.getConfig() >> [cpus: 2, memory: "1GB"]
+
+        when:
+        def task = JobBuilder.createTask(taskRun, args, env, jobOpts)
+
+        then:
+        task.config.network_mode == "test"
+    }
 }


### PR DESCRIPTION
allow to configure the network to join of the task

following Hashicorp documentation 

Mode of the network. This option is only supported on Linux clients. The following modes are available:

[none](https://developer.hashicorp.com/nomad/docs/job-specification/network#none) - Task group will have an isolated network without any network interfaces.

[bridge](https://developer.hashicorp.com/nomad/docs/job-specification/network#bridge) - Task group will have an isolated network namespace with an interface that is bridged with the host. Note that bridge networking is only currently supported for the docker, exec, raw_exec, and java task drivers.

[host](https://developer.hashicorp.com/nomad/docs/job-specification/network#host) - Each task will join the host network namespace and a shared network namespace is not created.

[cni network name](https://developer.hashicorp.com/nomad/docs/job-specification/network#cni) - Task group will have an isolated network namespace with the network configured by CNI.

