### PR TITLE
Fix job meta regarding secrets

### DIFF
--- a/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
@@ -71,6 +71,22 @@ class NomadJobOpts{
      * or via NF_NOMAD_IDENTITY_ENV_PASSTHROUGH=COMMA,SEPARATED.
      */
     List<String> identityEnvPassthrough
+    /**
+     * Names of head-task environment variables that must flow to every
+     * spawned child task as **task env only** — never recorded as job meta.
+     * Use this for SECRETS (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+     * registry credentials, ...) that the worker needs at runtime but
+     * must never leak through `nomad job inspect` / alloc inspection /
+     * audit logs.
+     *
+     * Distinct from {@link #identityEnvPassthrough}, which intentionally
+     * mirrors the env value into Job.Meta as well (for identity
+     * correlation — user, workspace, pipeline, ...). Default empty.
+     *
+     * Configure as: {@code nomad.jobs.secretEnvPassthrough = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']}
+     * or via NF_NOMAD_SECRET_ENV_PASSTHROUGH=COMMA,SEPARATED.
+     */
+    List<String> secretEnvPassthrough
     Duration shutdownDelay
     Map<String, Object> restartPolicy
     Map<String, Object> reschedulePolicy
@@ -129,6 +145,9 @@ class NomadJobOpts{
         identityEnvPassthrough = parseStringList(
                 nomadJobOpts.get('identityEnvPassthrough'),
                 sysEnv.get('NF_NOMAD_IDENTITY_ENV_PASSTHROUGH'))
+        secretEnvPassthrough = parseStringList(
+                nomadJobOpts.get('secretEnvPassthrough'),
+                sysEnv.get('NF_NOMAD_SECRET_ENV_PASSTHROUGH'))
         shutdownDelay = parseOptionalDuration(nomadJobOpts.shutdownDelay)
 
         Map<String, Object> failures = nomadJobOpts.failures instanceof Map ? (nomadJobOpts.failures as Map<String, Object>) : Collections.emptyMap()

--- a/src/main/groovy/nextflow/nomad/executor/NomadTaskHandler.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadTaskHandler.groovy
@@ -389,10 +389,16 @@ class NomadTaskHandler extends TaskHandler implements FusionAwareTask {
         }
 
         // Identity correlation envs — Nextflow + Nomad-native signals plus
-        // any harness-supplied env vars (via nomad.jobs.identityEnvPassthrough).
-        // Mirrors NomadService.buildIdentityMeta so worker bootstrap log lines
-        // and child Job.Meta carry the same correlation fields.
-        ret += buildIdentityEnv(task, config?.jobOpts()?.identityEnvPassthrough ?: Collections.<String>emptyList())
+        // any harness-supplied env vars (via nomad.jobs.identityEnvPassthrough
+        // and nomad.jobs.secretEnvPassthrough). Both lists flow to task env;
+        // only identityEnvPassthrough is mirrored into Job.Meta (see
+        // NomadService.buildIdentityMeta). Use secretEnvPassthrough for
+        // secrets (AWS keys, registry creds) that must not be readable via
+        // `nomad job inspect`.
+        List<String> envOnly = new ArrayList<>()
+        envOnly.addAll(config?.jobOpts()?.identityEnvPassthrough ?: Collections.<String>emptyList())
+        envOnly.addAll(config?.jobOpts()?.secretEnvPassthrough ?: Collections.<String>emptyList())
+        ret += buildIdentityEnv(task, envOnly)
 
         return ret
     }


### PR DESCRIPTION
This pull request introduces a new mechanism for securely passing sensitive environment variables (such as AWS credentials) to Nomad task environments without exposing them in job metadata or logs. It does so by adding a new configuration option and updating the environment propagation logic.

**Secure environment variable propagation:**

* Added a new `secretEnvPassthrough` property to `NomadJobOpts`, allowing configuration of environment variables that should be passed only to the task environment and never included in job metadata. This is intended for secrets and sensitive credentials.
* Updated the initialization logic in `NomadJobOpts` to parse and populate the new `secretEnvPassthrough` property from both config files and the `NF_NOMAD_SECRET_ENV_PASSTHROUGH` environment variable.

**Task handler environment setup:**

* Modified `NomadTaskHandler` so that both `identityEnvPassthrough` and `secretEnvPassthrough` variables are injected into the task environment, but only `identityEnvPassthrough` variables are mirrored into job metadata. This ensures secrets are available to the task but not exposed via Nomad job inspection or logs.