### PR TITLE
detect failsafe version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version= 0.4.0-edge7
+version= 0.4.0-edge8
 github_organization=nextflow-io

--- a/src/e2e/nf-test
+++ b/src/e2e/nf-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 APP_HOME="$HOME/.nf-test"
 APP_JAR="nf-test.jar"
 APP_UPDATE_URL="https://code.askimed.com/install/nf-test"

--- a/src/e2e/run-all.sh
+++ b/src/e2e/run-all.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+export NXF_SYNTAX_PARSER=v1
 sudo rm -rf /tmp/nomad/nomad_temp/scratchdir/tests/
-NXF_ASSETS=/tmp/nomad/nomad_temp/scratchdir/assets ./nf-test test
+NXF_ASSETS=/tmp/nomad/nomad_temp/scratchdir/assets ./nf-test test $@

--- a/src/main/groovy/nextflow/nomad/executor/FailsafeExecutor.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/FailsafeExecutor.groovy
@@ -2,16 +2,20 @@ package nextflow.nomad.executor
 
 import dev.failsafe.Failsafe
 import dev.failsafe.RetryPolicy
+import dev.failsafe.RetryPolicyBuilder
 import dev.failsafe.event.EventListener
 import dev.failsafe.event.ExecutionAttemptedEvent
 import dev.failsafe.function.CheckedSupplier
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.nomadproject.client.ApiException
 import nextflow.nomad.config.RetryConfig
 
+import java.lang.reflect.Proxy
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeoutException
+import java.util.function.BiPredicate
 import java.util.function.Predicate
 
 @Slf4j
@@ -24,6 +28,37 @@ class FailsafeExecutor {
         this.config = config
     }
 
+
+    protected <T> RetryPolicyBuilder<T> builderWithHandleIf(Predicate<? extends Throwable> cond){
+        def builder = RetryPolicy.<T>builder()
+
+        // 3.1.0
+        def predicateMethod = builder.class.methods.find {
+            it.name == 'handleIf' && it.parameterCount == 1 && it.parameterTypes[0] == Predicate}
+        if (predicateMethod) {
+            return builder.handleIf(cond)
+        }
+
+        // 3.3.2
+        def checkedpredicateMethod = builder.class.methods.find {
+            it.name == 'handleIf' && it.parameterCount == 1 && it.parameterTypes[0].name.endsWith("CheckedPredicate")}
+        if (!checkedpredicateMethod) {
+            throw new IllegalStateException("No valid failsafe library detected.")
+        }
+
+        def targetParamType = checkedpredicateMethod.parameterTypes[0]
+        def proxyInstance = Proxy.newProxyInstance(
+                targetParamType.classLoader,
+                [targetParamType] as Class[],
+                { proxy, m, args ->
+                    return cond.test((Throwable)args[0])
+                }
+        )
+        checkedpredicateMethod.invoke(builder, proxyInstance)
+
+        return builder
+    }
+
     protected <T> RetryPolicy<T> retryPolicy(Predicate<? extends Throwable> cond) {
 
         final listener = new EventListener<ExecutionAttemptedEvent<T>>() {
@@ -32,8 +67,8 @@ class FailsafeExecutor {
                 log.debug("Nomad TooManyRequests response error - attempt: ${event.attemptCount}; reason: ${event.lastFailure.message}")
             }
         }
-        return RetryPolicy.<T>builder()
-                .handleIf(cond)
+        RetryPolicyBuilder<T> builder = builderWithHandleIf(cond)
+        return builder
                 .withBackoff(config.delay.toMillis(), config.maxDelay.toMillis(), ChronoUnit.MILLIS)
                 .withMaxAttempts(config.maxAttempts)
                 .withJitter(config.jitter)

--- a/validation/basic/nextflow.config
+++ b/validation/basic/nextflow.config
@@ -14,7 +14,8 @@ nomad {
 
     jobs {
         deleteOnCompletion = false
-        volume = { type "host" name "scratchdir" }
+        volume = [ type: "host", name: "scratchdir" ]
+        nodePool = "dev"
     }
 
 }


### PR DESCRIPTION
as mentioned in #129 

"due to a binary incompatibility in the failsafe library. Nextflow 26.04.3 upgraded its bundled failsafe from 3.1.0 (shipped in 26.04.0) to 3.3.2, and RetryPolicyBuilder.handleIf(java.util.function.Predicate) was removed in that release."

this PR detects at runtime which failsafe version is present and use a java.Proxy in case is using latest releases

I've tested using
 nextflow  25.10.4 , 26.03.0-edge and  26.04.3
and 
  java 25.0.1-tem, 21.0.2-graalce and 26.0.1-amzn

and all tests are green (needed to relax the parser with nextflow 26.04.3)



closes #129 