### PR TITLE
fix(executor): honor executor.queueSize to gate task submission

### DIFF
--- a/src/main/groovy/nextflow/nomad/executor/NomadExecutor.groovy
+++ b/src/main/groovy/nextflow/nomad/executor/NomadExecutor.groovy
@@ -73,7 +73,15 @@ class NomadExecutor extends Executor implements ExtensionPoint {
 
     @Override
     protected TaskMonitor createTaskMonitor() {
-        TaskPollingMonitor.create(session, config, name, Duration.of('5 sec'))
+        // Use the 5-arg overload (with a defQueueSize) so executor.queueSize is
+        // honored: it is the only TaskPollingMonitor.create() variant that reads
+        // config.getQueueSize(name, default) and sets capacity > 0, which gates
+        // submission via checkQueueCapacity. The 4-arg overload drops the default,
+        // leaves capacity = 0 (unlimited), and every ready task is submitted to
+        // Nomad at once — overrunning a small/contended cluster's pending queue.
+        // 100 mirrors AbstractGridExecutor (SLURM/PBS), so behaviour matches the
+        // grid executors users expect.
+        TaskPollingMonitor.create(session, config, name, 100, Duration.of('5 sec'))
     }
 
     @Override

--- a/src/test/groovy/nextflow/nomad/executor/NomadExecutorSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/executor/NomadExecutorSpec.groovy
@@ -17,9 +17,12 @@
  */
 package nextflow.nomad.executor
 
+import nextflow.Session
+import nextflow.executor.ExecutorConfig
 import nextflow.nomad.builders.JobBuilder
 import nextflow.nomad.config.NomadConfig
 import nextflow.nomad.config.NomadJobOpts
+import nextflow.processor.TaskPollingMonitor
 import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import nextflow.script.ProcessConfig
@@ -71,6 +74,33 @@ class NomadExecutorSpec extends Specification {
             getProcessor() >> processor
             getName() >> "testTask"
         }
+    }
+
+    // ========================================================================
+    // createTaskMonitor — executor.queueSize must gate submission (capacity > 0)
+    // ========================================================================
+
+    @Unroll
+    def "createTaskMonitor honors executor.queueSize: #cfg → capacity #expected"() {
+        given:
+        def executor = new NomadExecutor()
+        executor.session = Mock(Session)
+        executor.name = 'nomad'
+        executor.config = new ExecutorConfig(cfg)
+
+        when:
+        def monitor = executor.createTaskMonitor()
+
+        then: 'capacity is wired from queueSize — the 4-arg overload left it 0 (unlimited)'
+        monitor instanceof TaskPollingMonitor
+        (monitor as TaskPollingMonitor).capacity == expected
+        (monitor as TaskPollingMonitor).capacity > 0
+
+        where:
+        cfg            | expected
+        [queueSize: 7] | 7    // user/abc executor.queueSize is honored
+        [queueSize: 2] | 2    // small-cluster throttle drains a deep DAG safely
+        [:]            | 100  // default mirrors AbstractGridExecutor (SLURM/PBS)
     }
 
     // ========================================================================


### PR DESCRIPTION
## Problem

`NomadExecutor.createTaskMonitor()` calls the **4-arg** `TaskPollingMonitor.create(session, config, name, pollInterval)` overload, which does not take a `defQueueSize`. That overload leaves the monitor's `capacity` at its default of `0`, and `TaskPollingMonitor.canSubmit()` treats `capacity == 0` as **unlimited** — so every ready task is submitted to Nomad immediately and `executor.queueSize` has no effect.

On a small or contended cluster this means a fan-out stage dumps far more task-jobs into Nomad than can be placed; they pile up `pending`, and (with a placement-failure deadline configured) eventually fail against `maxRetries`. There is no working knob to throttle in-flight submission.

Reproduced on a 3-node Nomad cluster: with `executor.queueSize = 2` set, 21 task-jobs were in flight (2 running, 19 pending) — queueSize was clearly not capping submission.

## Fix

Switch to the **5-arg** `TaskPollingMonitor.create(session, config, name, defQueueSize, pollInterval)` overload with `defQueueSize = 100` — the same value `AbstractGridExecutor.createTaskMonitor()` uses for the SLURM/PBS grid executors. That overload reads `config.getQueueSize(name, default)` and sets `capacity > 0`, so submission is gated via `checkQueueCapacity()` and a user-configured `executor.queueSize` is honored, matching the behaviour grid-executor users already expect.

One line of production code; behaviour for users who don't set `queueSize` is unchanged except that the implicit cap is now 100 (the grid-executor default) instead of unlimited.

## Test

Adds a parametrized spec asserting `createTaskMonitor().capacity` equals the configured `executor.queueSize` (and the 100 default), guarding against a regression back to the `0`/unlimited path.