### PR TITLE
test(constraints): guard raw(key, op, value) operator passthrough

### DIFF
--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderNomadOptionsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderNomadOptionsSpec.groovy
@@ -85,6 +85,28 @@ class JobBuilderNomadOptionsSpec extends Specification {
         taskDef.constraints[0].getRtarget() == 'pinned-host'
     }
 
+    void "constraints raw(key, op, value) renders an arbitrary operator (not just '=')"() {
+        // The map/shorthand closure form — node { class = 'x' } — hardcodes the
+        // '=' operator. The raw(...) form is the only way to express any other
+        // operator (!=, >, <, regexp, ...). Guard that the operator is passed
+        // through to the rendered Nomad constraint verbatim.
+        given:
+        Closure rawConstraint = { node { raw('class', '!=', 'spot') } }
+        def task = taskWithConfig([
+                (TaskDirectives.NOMAD_OPTIONS): [constraints: rawConstraint]
+        ])
+        def taskDef = new Task()
+
+        when:
+        JobBuilder.constraints(task, taskDef, Stub(NomadJobOpts))
+
+        then:
+        taskDef.constraints.size() == 1
+        taskDef.constraints[0].getLtarget() == '${node.class}'
+        taskDef.constraints[0].getOperand() == '!='
+        taskDef.constraints[0].getRtarget() == 'spot'
+    }
+
     void "secrets should prefer nomadOptions secrets list"() {
         given:
         def task = taskWithConfig([


### PR DESCRIPTION
## Description

The per-process constraints DSL supports two closure forms:
- the map/shorthand — `node { class = 'x' }` — which hardcodes the `=` operator, and
- the `raw(key, op, value)` form — the only way to express any other operator (`!=`, `>`, `<`, regexp, …).

The shorthand `=` path is covered by an existing spec, but there was **no test** asserting that `raw(...)` carries its operator through to the rendered Nomad constraint. A refactor of the constraint builder could silently drop or coerce the operator (e.g. emit `=`) without any test failing.

## What was added

Adds a unit test asserting `{ node { raw('class', '!=', 'spot') } }` renders to a constraint with `ltarget = ${node.class}`, `operand = !=`, `rtarget = spot`.

Test-only; no production change.