### PR TITLE
fix(executor): default task RestartPolicy attempts to 0 so Nextflow owns retries

### DIFF
--- a/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
+++ b/src/main/groovy/nextflow/nomad/builders/JobBuilder.groovy
@@ -745,7 +745,19 @@ class JobBuilder {
             effective.putAll(override)
         }
 
-        RestartPolicy policy = new RestartPolicy().attempts(parseInteger(effective.get("attempts"), jobOpts?.restartAttempts ?: 1))
+        // Default restart attempts is 0 (no in-place Nomad restart). A Nomad restart
+        // re-runs the failed attempt in the SAME allocation and SAME work dir, which
+        // still holds the previous attempt's partial outputs. With `bash -C` (noclobber,
+        // the nf-core default since 4.0) a `... 2> ${prefix}.log` redirect then fails
+        // with "cannot overwrite existing file", turning a transient first-attempt
+        // failure permanently fatal — and risks acting on stale partial outputs.
+        // Nextflow owns retries: `errorStrategy 'retry'` re-submits the task under a NEW
+        // task hash in a FRESH work dir, which is idempotent. So we default to 0 in-place
+        // restarts and let Nextflow retry cleanly. An explicit config value (per-task
+        // override, `failures.restart.attempts`, or `restartAttempts`) still wins.
+        // Reschedule is left at its default (a reschedule is a new allocation with a
+        // fresh dir, so it doesn't hit the noclobber bug — see resolveReschedulePolicy).
+        RestartPolicy policy = new RestartPolicy().attempts(parseInteger(effective.get("attempts"), jobOpts?.restartAttempts ?: 0))
         Long delay = parseDurationToMillis(effective.get("delay"))
         if( delay != null ) {
             policy.delay(delay)

--- a/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
+++ b/src/main/groovy/nextflow/nomad/config/NomadJobOpts.groovy
@@ -154,9 +154,12 @@ class NomadJobOpts{
         restartPolicy = failures.restart instanceof Map ? (failures.restart as Map<String, Object>) : Collections.emptyMap()
         reschedulePolicy = failures.reschedule instanceof Map ? (failures.reschedule as Map<String, Object>) : Collections.emptyMap()
 
-        //NOTE: Default to a single attempt per nomad job definition
+        //NOTE: Default reschedule to a single attempt per nomad job definition.
+        // Restart defaults to 0: an in-place Nomad restart reuses the task work dir
+        // (same alloc), breaking `bash -C` noclobber redirects and idempotent
+        // re-execution. Nextflow owns retries (fresh task-hash dir via errorStrategy).
         rescheduleAttempts = nomadJobOpts.rescheduleAttempts as Integer ?: 1
-        restartAttempts = nomadJobOpts.restartAttempts as Integer ?: 1
+        restartAttempts = nomadJobOpts.restartAttempts as Integer ?: 0
         privileged = nomadJobOpts.containsKey("privileged")
                 ? Boolean.valueOf(nomadJobOpts.privileged.toString())
                 : true

--- a/src/test/groovy/nextflow/nomad/builders/JobBuilderNomadOptionsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/builders/JobBuilderNomadOptionsSpec.groovy
@@ -480,6 +480,83 @@ class JobBuilderNomadOptionsSpec extends Specification {
         policy.getUnlimited() == true
     }
 
+    void "resolveRestartPolicy should default to zero attempts so Nextflow owns retries"() {
+        given: 'a task with no restart config and jobOpts carrying the default restartAttempts'
+        def task = taskWithConfig([:])
+        def jobOpts = Stub(NomadJobOpts) {
+            getRestartAttempts() >> 0
+            getRestartPolicy() >> [:]
+        }
+
+        when:
+        def policy = JobBuilder.resolveRestartPolicy(task, jobOpts)
+
+        then: 'no in-place Nomad restart -- avoids reusing the work dir and breaking noclobber redirects'
+        policy.getAttempts() == 0
+    }
+
+    void "resolveRestartPolicy should honour an explicit restartAttempts override over the default"() {
+        given:
+        def task = taskWithConfig([:])
+        def jobOpts = Stub(NomadJobOpts) {
+            getRestartAttempts() >> 2
+            getRestartPolicy() >> [:]
+        }
+
+        when:
+        def policy = JobBuilder.resolveRestartPolicy(task, jobOpts)
+
+        then: 'the explicit value wins -- the 0 default never clobbers a configured value'
+        policy.getAttempts() == 2
+    }
+
+    void "resolveRestartPolicy should honour an explicit failures.restart.attempts map over the default"() {
+        given:
+        def task = taskWithConfig([:])
+        def jobOpts = Stub(NomadJobOpts) {
+            getRestartAttempts() >> 0
+            getRestartPolicy() >> [attempts: 3]
+        }
+
+        when:
+        def policy = JobBuilder.resolveRestartPolicy(task, jobOpts)
+
+        then:
+        policy.getAttempts() == 3
+    }
+
+    void "resolveRestartPolicy should honour a per-task restart override over the default"() {
+        given:
+        def task = taskWithConfig([
+                (TaskDirectives.NOMAD_OPTIONS): [failures: [restart: [attempts: 4]]]
+        ])
+        def jobOpts = Stub(NomadJobOpts) {
+            getRestartAttempts() >> 0
+            getRestartPolicy() >> [:]
+        }
+
+        when:
+        def policy = JobBuilder.resolveRestartPolicy(task, jobOpts)
+
+        then:
+        policy.getAttempts() == 4
+    }
+
+    void "resolveReschedulePolicy should keep its default of one attempt"() {
+        given: 'a task with no reschedule config -- guards against accidentally moving the reschedule default'
+        def task = taskWithConfig([:])
+        def jobOpts = Stub(NomadJobOpts) {
+            getRescheduleAttempts() >> 1
+            getReschedulePolicy() >> [:]
+        }
+
+        when:
+        def policy = JobBuilder.resolveReschedulePolicy(task, jobOpts)
+
+        then: 'a reschedule is a new allocation with a fresh dir, so it does not hit the noclobber bug'
+        policy.getAttempts() == 1
+    }
+
     void "resolveShutdownDelayMillis should prefer process nomadOptions over global setting"() {
         given:
         def task = taskWithConfig([

--- a/src/test/groovy/nextflow/nomad/config/NomadJobOptsSpec.groovy
+++ b/src/test/groovy/nextflow/nomad/config/NomadJobOptsSpec.groovy
@@ -34,7 +34,7 @@ class NomadJobOptsSpec extends Specification {
 
         expect:
         nomadJobOpts.rescheduleAttempts == 1
-        nomadJobOpts.restartAttempts == 1
+        nomadJobOpts.restartAttempts == 0
         nomadJobOpts.dockerVolume == null
         nomadJobOpts.driver == "docker"
         nomadJobOpts.cpuMode == NomadJobOpts.CPU_MODE_CORES


### PR DESCRIPTION
## Problem

Each spawned Nomad task job is created with `RestartPolicy.Attempts = 1` (the default). When a task's first attempt fails, Nomad restarts it **in-place** — same allocation, same working directory — which still contains the previous attempt's partial outputs. This breaks retries:

1. **Noclobber (fatal):** nf-core sets `process.shell = ['bash','-C',...]` (noclobber, default since nf-core 4.0), so `.command.sh` runs under `-C`. Modules commonly redirect to a fixed file, e.g. `... 2> ${prefix}.log`. On the in-place restart that file already exists, so `2>` under `-C` fails with `cannot overwrite existing file` → exit 1 → the task fails permanently. A *transient* first-attempt failure (preemption, node blip, placement hiccup) thus becomes fatal.
2. **Stale partial outputs:** re-running in the same dir leaves attempt 1's half-written outputs and scratch trees present, which can corrupt or confuse the retry.

This pre-empts Nextflow's own retry model, which re-submits a failed task as a **new task hash in a fresh work dir** (`errorStrategy 'retry'`) — the reason `-C` noclobber is safe on every other executor.

## Fix

Default the task `RestartPolicy.Attempts` to **0** (no in-place Nomad restart) and let Nextflow handle retries in a fresh work dir. Two spots:
- `JobBuilder.resolveRestartPolicy` — the unset default `jobOpts?.restartAttempts ?: 1` → `?: 0`.
- `NomadJobOpts.restartAttempts` — default `?: 1` → `?: 0`.

`ReschedulePolicy` is left at its default of 1 on purpose: a reschedule is a *new allocation* (fresh dir), so it doesn't trigger the noclobber/stale-output problem and still gives benign node-failure recovery. All override precedence is preserved — a per-task `failures.restart`, a `nomad.jobs.failures.restart.attempts` map, or `nomad.jobs.restartAttempts` still win; only the unset default moves 1 → 0.

## Tests

`NomadJobOptsSpec`: unset-default expectation 1 → 0 (explicit `restartAttempts: 2` test untouched). Added 5 specs: default yields attempts 0; explicit `restartAttempts` / `failures.restart.attempts` map / per-task override each still win; and a guard that the reschedule default stays 1. Full suite green (437 tests, 0 failures).